### PR TITLE
Fixed the problem with the binary type attribute in the schema

### DIFF
--- a/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/InterfaceGenerator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/InterfaceGenerator.java
@@ -139,7 +139,7 @@ public class InterfaceGenerator implements CodeGenerator, ElementVisitor {
 		}
 		
 		//generate getDefault function only for primitive field
-		if (type instanceof PrimitiveFieldType) {
+		if (type instanceof PrimitiveFieldType && ((PrimitiveFieldType) type).getType() != PrimitiveType.BINARY) {
 			currentTemplate.fillFields("fieldDefaultValue", 
 					templateGenerator.getDefaultValueTemplate());
 		}

--- a/RecordBuffers/src/main/java/datamine/storage/idl/generator/metadata/MetadataFileGenerator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/generator/metadata/MetadataFileGenerator.java
@@ -159,7 +159,8 @@ public class MetadataFileGenerator implements ElementVisitor,
 		
 		FieldType type = field.getType();
 		// the field does not have the default unless it is optional and primitive
-		if (field.isRequired() || !(type instanceof PrimitiveFieldType)) {
+		if (field.isRequired() || !(type instanceof PrimitiveFieldType) ||
+			(type instanceof PrimitiveFieldType && ((PrimitiveFieldType)type).getType() == PrimitiveType.BINARY)) {
 			sb.append("null"); // default value
 			
 		} else {

--- a/RecordBuffers/src/main/java/datamine/storage/idl/json/JsonFieldType.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/json/JsonFieldType.java
@@ -15,6 +15,10 @@
  */
 package datamine.storage.idl.json;
 
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.google.common.collect.Lists;
+
 /**
  * The ENUM defines all types in the JSON schema. 
  * 
@@ -22,7 +26,7 @@ package datamine.storage.idl.json;
  * @date Dec 11, 2014
  */
 public enum JsonFieldType {
-	
+
 	Boolean("Boolean", true) {
 		@Override
 		Object parseValue(java.lang.String valueStr) {
@@ -71,30 +75,51 @@ public enum JsonFieldType {
 			return valueStr;
 		}
 	},
+	Binary("Binary", true) {
+		@Override
+		Object parseValue(java.lang.String valueStr) {
+			// verify the input
+			if (!valueStr.startsWith("[") || !valueStr.endsWith("]")) {
+				throw new IllegalArgumentException("A value of binary should start "
+						+ "with '[' and end with ']', e.g., [2, 3]");
+			}
+			// convert the input into a value
+			String[] byteValues = valueStr.substring(1, valueStr.length() - 1).split(",");
+			java.util.List<Byte> list = Lists.newArrayList();
+
+			for (String cur : byteValues) {
+				if (cur.trim().isEmpty()) {
+					continue;
+				}
+				list.add(java.lang.Byte.parseByte(cur.trim()));
+			}
+			return ArrayUtils.toPrimitive(list.toArray(new Byte[list.size()]));
+		}
+	},
 	Struct("Struct", false) {
 		@Override
 		Object parseValue(java.lang.String valueStr) {
-			return valueStr;
+			throw new IllegalAccessError("Conversion from String to Struct is not supported!");
 		}
 	},
 	List("List", false) {
 		@Override
 		Object parseValue(java.lang.String valueStr) {
-			return valueStr;
+			throw new IllegalAccessError("Conversion from String to List is not supported!");
 		}
 	};
-	
+
 	static final String JSON_LIST_ELEMENT_TYPE_DELIMITER = ":";
 	String name;
 	boolean isPrimitive;
-	
+
 	private JsonFieldType(String name, boolean isPrimitive) {
 		this.name = name;
 		this.isPrimitive = isPrimitive;
 	}
-	
+
 	abstract Object parseValue(String valueStr);
-	
+
 	/**
 	 * Get the corresponding type given a text input. 
 	 * <p>
@@ -117,7 +142,7 @@ public enum JsonFieldType {
 			return JsonFieldType.Struct;
 		}
 	}
-		
+
 	/**
 	 * Return the JSON field type of the element in a LIST structure.
 	 * @param name the text representation of a JSON LIST type. 
@@ -126,7 +151,7 @@ public enum JsonFieldType {
 	public static JsonFieldType getElementTypeInList(String name) {
 		return getType(getElementTypeNameInList(name));
 	}
-	
+
 	/**
 	 * Get the type name of the element in a LIST structure.
 	 * @param name the text representation of a JSON LIST type.

--- a/RecordBuffers/src/main/java/datamine/storage/idl/json/JsonSchemaConvertor.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/json/JsonSchemaConvertor.java
@@ -80,8 +80,10 @@ public class JsonSchemaConvertor implements JsonElementVisitor,
 		// Sanity check: 
 		/// 1. an optional primitive field must have a default value
 		if (defaultValue == null && type instanceof PrimitiveFieldType && !field.isRequired()) {
-			throw new IllegalArgumentException("Default value " +
-					"is required for the optional primitive column - " + field.getName());
+			if (((PrimitiveFieldType) type).getType() != PrimitiveType.BINARY) {
+				throw new IllegalArgumentException("Default value " +
+						"is required for the optional primitive column - " + field.getName());				
+			}
 		}
 		
 		/// 2. sort-key column must be required
@@ -125,7 +127,9 @@ public class JsonSchemaConvertor implements JsonElementVisitor,
 		case Double:
 			return new PrimitiveFieldType(PrimitiveType.DOUBLE); 
 		case String:
-			return new PrimitiveFieldType(PrimitiveType.STRING); 
+			return new PrimitiveFieldType(PrimitiveType.STRING);
+		case Binary:
+			return new PrimitiveFieldType(PrimitiveType.BINARY);
 		case Struct:
 			embededTableName.add(typeStr);
 			return new GroupFieldType(typeStr, null);

--- a/RecordBuffers/src/main/java/datamine/storage/idl/validate/FieldValidation.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/validate/FieldValidation.java
@@ -21,6 +21,7 @@ import datamine.storage.idl.Field;
 import datamine.storage.idl.Field.Constraint;
 import datamine.storage.idl.type.FieldType;
 import datamine.storage.idl.type.PrimitiveFieldType;
+import datamine.storage.idl.type.PrimitiveType;
 import datamine.storage.idl.validate.exceptions.AbstractValidationException;
 import datamine.storage.idl.validate.exceptions.IllegalDerivedFieldException;
 import datamine.storage.idl.validate.exceptions.IllegalFieldDefaultValueException;
@@ -82,11 +83,15 @@ class FieldValidation implements ValidateInterface<Field> {
 		// validate its type and default value
 		Object defaultVal = input.getDefaultValue();
 		
-		if (type instanceof PrimitiveFieldType && !input.isRequired()) {
+		if (type instanceof PrimitiveFieldType && 
+			((PrimitiveFieldType) type).getType() != PrimitiveType.BINARY && 
+			!input.isRequired()) {
+			
 			if (!FieldValueOperatorFactory.getOperator(type).isValid(defaultVal)) {
 				throw new IllegalFieldDefaultValueException(
 						fieldName, defaultVal + " is not valid!");
 			}
+			
 		} else {
 			if (defaultVal != null) {
 				throw new IllegalFieldDefaultValueException(

--- a/RecordBuffers/src/main/java/datamine/storage/idl/validate/SchemaEvolutionValidation.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/validate/SchemaEvolutionValidation.java
@@ -28,6 +28,7 @@ import datamine.storage.idl.Schema;
 import datamine.storage.idl.Table;
 import datamine.storage.idl.Field.Constraint;
 import datamine.storage.idl.type.PrimitiveFieldType;
+import datamine.storage.idl.type.PrimitiveType;
 import datamine.storage.idl.validate.exceptions.AbstractValidationException;
 import datamine.storage.idl.validate.exceptions.FieldConstraintModifiedInSchemaEvolutionException;
 import datamine.storage.idl.validate.exceptions.FieldDefaultValueModifiedInSchemaEvolutionException;
@@ -114,7 +115,7 @@ public class SchemaEvolutionValidation implements ValidateInterface<Schema> {
 		
 		//2.1 ensure all fields in the current table do exist still
 		if (fieldsInCurrentTable.size() > fieldsInNextTable.size()) {
-			throw new FieldDeletionInSchemaEvolutionException("Some");
+			throw new FieldDeletionInSchemaEvolutionException("Some old fields");
 		}
 		
 		for (Field cur : fieldsInCurrentTable) {
@@ -171,11 +172,9 @@ public class SchemaEvolutionValidation implements ValidateInterface<Schema> {
 
 		// check the default value
 		if (!current.isRequired() && current.getType() instanceof PrimitiveFieldType &&
+			((PrimitiveFieldType) current.getType()).getType() != PrimitiveType.BINARY && 
 			!current.getDefaultValue().equals(next.getDefaultValue())) {
 			throw new FieldDefaultValueModifiedInSchemaEvolutionException(current.getName());
 		}
-			
-		
 	}
-	
 }

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/ReadOnlyRecord.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/ReadOnlyRecord.java
@@ -214,7 +214,8 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 		if (offset > 0) {
 			int length = buffer.getByteBuffer().getInt(offset);
 			byte[] out = new byte[length];
-			buffer.getByteBuffer().get(out, offset + 4, length);
+			byte[] src = buffer.getByteBuffer().array();
+			System.arraycopy(src, offset + 4, out, 0, length);
 			return out;
 		} else {
 			return (byte[]) col.getField().getDefaultValue();
@@ -308,14 +309,14 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 					case STRING:
 						// string requires a SHORT to store its length (max < 32k)
 						short arrayLength = bytebuffer.getShort(offset);
-						if (arrayLength > 0) {
+						if (arrayLength >= 0) {
 							offset += 2 + arrayLength;	
 						}
 						break;
 					case BINARY:
 						// other types require a INT to store its length info
 						int arrayLength2 = bytebuffer.getInt(offset);
-						if (arrayLength2 > 0) {
+						if (arrayLength2 >= 0) {
 							offset += 4 + arrayLength2;	
 						}
 						break;
@@ -326,12 +327,12 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 					}
 				} else if (fieldType instanceof GroupFieldType) {
 					int arrayLength2 = bytebuffer.getInt(offset);
-					if (arrayLength2 > 0) {
+					if (arrayLength2 >= 0) {
 						offset += 4 + arrayLength2;	
 					}
 				} else if (fieldType instanceof CollectionFieldType) {
 					int arrayLength2 = bytebuffer.getInt(offset);
-					if (arrayLength2 > 0) {
+					if (arrayLength2 >= 0) {
 						offset += 4 + arrayLength2;	
 					}
 				}

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
@@ -269,7 +269,7 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 					case STRING:
 						// string requires a SHORT to store its length (max < 32k)
 						short arrayLength = bytebuffer.getShort(offset);
-						if (arrayLength > 0) {
+						if (arrayLength >= 0) {
 							valueArray[id] = valueOpr.getValue(bytebuffer, offset + 2, arrayLength);
 							offset += 2 + arrayLength;	
 						}
@@ -277,7 +277,7 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 					case BINARY:
 						// other types require a INT to store its length info
 						int arrayLength2 = bytebuffer.getInt(offset);
-						if (arrayLength2 > 0) {
+						if (arrayLength2 >= 0) {
 							valueArray[id] = valueOpr.getValue(bytebuffer, offset + 4, arrayLength2);
 							offset += 4 + arrayLength2;	
 						}
@@ -411,7 +411,7 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 							!curField.equalToDefaultValue(val)) {
 
 						byte[] byteArray = valOpr.getByteArray(val);
-						if (byteArray.length > 0) {
+						if (byteArray.length >= 0) { // a dummy '0' must be written even if it has no value
 
 							hasValidValue = true;
 

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/idl/generator/RecordMetaWrapperGenerator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/idl/generator/RecordMetaWrapperGenerator.java
@@ -608,7 +608,7 @@ public class RecordMetaWrapperGenerator implements ElementVisitor,
 			field = input;
 			FieldType type = input.getType();
 			
-			if (type instanceof PrimitiveFieldType) {
+			if (type instanceof PrimitiveFieldType && ((PrimitiveFieldType) type).getType() != PrimitiveType.BINARY) {
 				fieldGetterTemplate = new CodeTemplate(code);
 				
 				String javaTypeStr = new JavaTypeConvertor().apply(type);

--- a/RecordBuffers/src/test/java/datamine/storage/idl/generator/RandomValueGenerator.java
+++ b/RecordBuffers/src/test/java/datamine/storage/idl/generator/RandomValueGenerator.java
@@ -19,9 +19,9 @@ import java.util.List;
 import java.util.Random;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.testng.collections.Lists;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 import datamine.storage.idl.type.PrimitiveType;
 
@@ -60,7 +60,7 @@ public class RandomValueGenerator {
 		case STRING:
 			return "abasf_"+System.currentTimeMillis();//rand2.random(256);
 		case BINARY:
-			byte[] ret = new byte[(Integer) getValueOf(PrimitiveType.INT32)];
+			byte[] ret = new byte[1000];
 			rand1.nextBytes(ret);
 			return ret;
 		case UNKNOWN:

--- a/RecordBuffers/src/test/java/datamine/storage/idl/json/JsonFieldTypeTest.java
+++ b/RecordBuffers/src/test/java/datamine/storage/idl/json/JsonFieldTypeTest.java
@@ -28,4 +28,27 @@ public class JsonFieldTypeTest {
 		Assert.assertEquals(JsonFieldType.getElementTypeInList(type),
 				JsonFieldType.Struct);
 	}
+	
+	@Test
+	public void getBinaryDefault() {
+		String value = "[]";
+		byte[] result = (byte[]) JsonFieldType.Binary.parseValue(value);
+		Assert.assertEquals(result.length, 0);
+		
+		value = "[2, 3]";
+		result = (byte[]) JsonFieldType.Binary.parseValue(value);
+		Assert.assertEquals(result.length, 2);
+	}
+	
+	@Test (expectedExceptions=IllegalAccessError.class)
+	public void parseString2Struct() {
+		String value = "qw2asfq245";
+		JsonFieldType.Struct.parseValue(value);
+	}
+	
+	@Test (expectedExceptions=IllegalAccessError.class)
+	public void parseString2List() {
+		String value = "qw2asfq245";
+		JsonFieldType.List.parseValue(value);
+	}
 }

--- a/RecordBuffers/src/test/java/datamine/storage/idl/validate/SchemaEvolutionValidationTest.java
+++ b/RecordBuffers/src/test/java/datamine/storage/idl/validate/SchemaEvolutionValidationTest.java
@@ -48,9 +48,74 @@ public class SchemaEvolutionValidationTest {
 		validate.check(nextSchema);
 	}
 	
+	/**
+	 * The exception is thrown out from datamine.storage.idl.json.JsonSchemaConvertor
+	 * 
+	 * @throws AbstractValidationException
+	 */
 	@Test(expectedExceptions = IllegalArgumentException.class)
 	public void checkNextSchema() throws AbstractValidationException {
-		String json_schema = "{\n  \"schema\": \"simple_schema\",\n  \"table_list\": [\n    {\n      \"table\": \"attribution_result_rule\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"default\": \"Unknown\"}\n      ]\n    },\n    {\n      \"table\": \"attribution_result\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"id\",\"type\": \"Integer\",\"isRequired\": true},\n        {\"id\": 2,\"name\": \"rules\",      \"type\": \"List:attribution_result_rule\", \"isRequired\": true}\n      ]\n    },\n    {\n      \"table\": \"impression\",\n      \"fields\": [\n        {\"id\": 1, \"name\": \"media_provider_id\", \"type\": \"Integer\",\"isRequired\": true},\n        {\"id\": 2,\"name\": \"mp_tpt_category_id\",\"type\": \"Short\",  \"default\": \"-1\"},\n        {\"id\": 3,\"name\": \"truncated_url\",     \"type\": \"String\", \"default\": \"Unknown\"},\n        {\"id\": 4,\"name\": \"bid\",         \"type\": \"Boolean\",  \"default\": \"true\"},\n        {\"id\": 5,\"name\": \"bid_type\",          \"type\": \"Byte\",   \"default\": \"-1\"},\n        {\"id\": 6,\"name\": \"attribution_results\",\"type\": \"List:attribution_result\"},\n        {\"id\": 7,\"name\": \"allowed_ad_formats\",\"type\": \"Long\",   \"default\": \"-1\"},\n\t\t{\"id\": 8,\"name\": \"cost\",\"type\": \"Double\",   \"default\": \"0\"}\n\t\t]\n    },\n    {\n      \"table\": \"provider_user_id\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"provider_type\",          \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"provider_id\",            \"type\": \"Integer\",\"isRequired\": true}\n      ]\n    },\n    {\n      \"table\": \"analytical_user_profile\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"user_id\",                 \"type\": \"Long\",   \"isRequired\": true, \"isFrequentlyUsed\": true},\n        {\"id\": 2,\"name\": \"version\",         \"type\": \"Byte\", \"isRequired\": true, \"isDesSortKey\": true},\n        {\"id\": 3,\"name\": \"resolution\",      \"type\": \"Short\",  \"default\": \"-1\"},\n        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\n        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\n        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\n\t\t{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"}\n      ]\n    }\n  ]\n}";
+		String json_schema = "{\r\n" + 
+				"  \"schema\": \"simple_schema\",\r\n" + 
+				"  \"table_list\": [\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"attribution_result_rule\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"default\": \"Unknown\"}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"attribution_result\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"id\",\"type\": \"Integer\",\"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"rules\",      \"type\": \"List:attribution_result_rule\", \"isRequired\": true}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"impression\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1, \"name\": \"media_provider_id\", \"type\": \"Integer\",\"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"mp_tpt_category_id\",\"type\": \"Short\",  \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 3,\"name\": \"truncated_url\",     \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
+				"        {\"id\": 4,\"name\": \"bid\",         \"type\": \"Boolean\",  \"default\": \"true\"},\r\n" + 
+				"        {\"id\": 5,\"name\": \"bid_type\",          \"type\": \"Byte\",   \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 6,\"name\": \"attribution_results\",\"type\": \"List:attribution_result\"},\r\n" + 
+				"        {\"id\": 7,\"name\": \"allowed_ad_formats\",\"type\": \"Long\",   \"default\": \"-1\"},\r\n" + 
+				"		{\"id\": 8,\"name\": \"cost\",\"type\": \"Double\",   \"default\": \"0\"}\r\n" + 
+				"		]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"provider_user_id\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"provider_type\",          \"type\": \"Byte\",   \"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"provider_id\",            \"type\": \"Integer\",\"isRequired\": true}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+//				"    {\r\n" + 
+//				"      \"table\": \"id_map\",\r\n" + 
+//				"      \"fields\": [\r\n" + 
+//				"        {\"id\": 1,\"name\": \"media_provider_ids\",\"type\": \"List:provider_user_id\"}\r\n" + 
+//				"      ]\r\n" + 
+//				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"analytical_user_profile\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"user_id\",                 \"type\": \"Long\",   \"isRequired\": true, \"isFrequentlyUsed\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"version\",         \"type\": \"Byte\", \"isRequired\": true, \"isDesSortKey\": true},\r\n" + 
+				"        {\"id\": 3,\"name\": \"resolution\",      \"type\": \"Short\",  \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
+				"        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\r\n" + 
+				"        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\r\n" + 
+				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"},\r\n" + 
+				"		{\"id\": 8, \"name\": \"data\",     \"type\": \"Binary\"},\r\n" + 
+				"		{\"id\": 0, \"name\": \"day\",     \"type\": \"String\", \"isDerived\": true, \"default\": \"Unknown\"}\r\n" + 
+				"      ]\r\n" + 
+				"    }\r\n" + 
+				"  ]\r\n" + 
+				"}\r\n" + 
+				"";
+		
 		Schema nextSchema = new JsonSchemaConvertor().apply(json_schema);
 		SchemaEvolutionValidation validate = 
 				new SchemaEvolutionValidation(currentSchema);
@@ -59,7 +124,66 @@ public class SchemaEvolutionValidationTest {
 	
 	@Test(expectedExceptions = FieldDeletionInSchemaEvolutionException.class)
 	public void checkFieldSchema() throws AbstractValidationException {
-		String json_schema = "{\n  \"schema\": \"simple_schema\",\n  \"table_list\": [\n    {\n      \"table\": \"attribution_result_rule\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"default\": \"Unknown\"}\n      ]\n    },\n    {\n      \"table\": \"attribution_result\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"id\",\"type\": \"Integer\",\"isRequired\": true},\n        {\"id\": 2,\"name\": \"rules\",      \"type\": \"List:attribution_result_rule\", \"isRequired\": true}\n      ]\n    },\n    {\n      \"table\": \"impression\",\n      \"fields\": [\n        {\"id\": 1, \"name\": \"media_provider_id\", \"type\": \"Integer\",\"isRequired\": true},\n        {\"id\": 2,\"name\": \"mp_tpt_category_id\",\"type\": \"Short\",  \"default\": \"-1\"},\n        {\"id\": 3,\"name\": \"truncated_url\",     \"type\": \"String\", \"default\": \"Unknown\"},\n        {\"id\": 4,\"name\": \"bid\",         \"type\": \"Boolean\",  \"default\": \"true\"},\n        {\"id\": 5,\"name\": \"bid_type\",          \"type\": \"Byte\",   \"default\": \"-1\"},\n        {\"id\": 6,\"name\": \"attribution_results\",\"type\": \"List:attribution_result\"},\n        {\"id\": 7,\"name\": \"allowed_ad_formats\",\"type\": \"Long\",   \"default\": \"-1\"}\n\t\t]\n    },\n    {\n      \"table\": \"provider_user_id\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"provider_type\",          \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"provider_id\",            \"type\": \"Integer\",\"isRequired\": true}\n      ]\n    },\n    {\n      \"table\": \"id_map\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"media_provider_ids\",\"type\": \"List:provider_user_id\"}\n      ]\n    },\n    {\n      \"table\": \"analytical_user_profile\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"user_id\",                 \"type\": \"Long\",   \"isRequired\": true, \"isFrequentlyUsed\": true},\n        {\"id\": 2,\"name\": \"version\",         \"type\": \"Byte\", \"isRequired\": true, \"isDesSortKey\": true},\n        {\"id\": 3,\"name\": \"resolution\",      \"type\": \"Short\",  \"default\": \"-1\"},\n        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\n        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\n        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\n\t\t{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"}\n      ]\n    }\n  ]\n}";
+		String json_schema = "{\r\n" + 
+				"  \"schema\": \"simple_schema\",\r\n" + 
+				"  \"table_list\": [\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"attribution_result_rule\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"default\": \"Unknown\"}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"attribution_result\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"id\",\"type\": \"Integer\",\"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"rules\",      \"type\": \"List:attribution_result_rule\", \"isRequired\": true}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"impression\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1, \"name\": \"media_provider_id\", \"type\": \"Integer\",\"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"mp_tpt_category_id\",\"type\": \"Short\",  \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 3,\"name\": \"truncated_url\",     \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
+				"        {\"id\": 4,\"name\": \"bid\",         \"type\": \"Boolean\",  \"default\": \"true\"},\r\n" + 
+				"        {\"id\": 5,\"name\": \"bid_type\",          \"type\": \"Byte\",   \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 6,\"name\": \"attribution_results\",\"type\": \"List:attribution_result\"},\r\n" + 
+				"        {\"id\": 7,\"name\": \"allowed_ad_formats\",\"type\": \"Long\",   \"default\": \"-1\"},\r\n" + 
+				"		{\"id\": 8,\"name\": \"cost\",\"type\": \"Double\",   \"default\": \"0\"}\r\n" + 
+				"		]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"provider_user_id\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"provider_type\",          \"type\": \"Byte\",   \"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"provider_id\",            \"type\": \"Integer\",\"isRequired\": true}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"id_map\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"media_provider_ids\",\"type\": \"List:provider_user_id\"}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"analytical_user_profile\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"user_id\",                 \"type\": \"Long\",   \"isRequired\": true, \"isFrequentlyUsed\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"version\",         \"type\": \"Byte\", \"isRequired\": true, \"isDesSortKey\": true},\r\n" + 
+				"        {\"id\": 3,\"name\": \"resolution\",      \"type\": \"Short\",  \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
+				"        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\r\n" + 
+				"        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\r\n" + 
+				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"},\r\n" + 
+				"		{\"id\": 0, \"name\": \"day\",     \"type\": \"String\", \"isDerived\": true, \"default\": \"Unknown\"}\r\n" + 
+				"      ]\r\n" + 
+				"    }\r\n" + 
+				"  ]\r\n" + 
+				"}\r\n" + 
+				"";
+				
 		Schema nextSchema = new JsonSchemaConvertor().apply(json_schema);
 		SchemaEvolutionValidation validate = 
 				new SchemaEvolutionValidation(currentSchema);
@@ -68,7 +192,67 @@ public class SchemaEvolutionValidationTest {
 	
 	@Test(expectedExceptions = FieldTypeModifiedInSchemaEvolutionException.class)
 	public void checkFieldTypeChangedSchema() throws AbstractValidationException {
-		String json_schema = "{\n  \"schema\": \"simple_schema\",\n  \"table_list\": [\n    {\n      \"table\": \"attribution_result_rule\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"default\": \"Unknown\"}\n      ]\n    },\n    {\n      \"table\": \"attribution_result\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"id\",\"type\": \"Integer\",\"isRequired\": true},\n        {\"id\": 2,\"name\": \"rules\",      \"type\": \"List:attribution_result_rule\", \"isRequired\": true}\n      ]\n    },\n    {\n      \"table\": \"impression\",\n      \"fields\": [\n        {\"id\": 1, \"name\": \"media_provider_id\", \"type\": \"Float\",\"isRequired\": true},\n        {\"id\": 2,\"name\": \"mp_tpt_category_id\",\"type\": \"Short\",  \"default\": \"-1\"},\n        {\"id\": 3,\"name\": \"truncated_url\",     \"type\": \"String\", \"default\": \"Unknown\"},\n        {\"id\": 4,\"name\": \"bid\",         \"type\": \"Boolean\",  \"default\": \"true\"},\n        {\"id\": 5,\"name\": \"bid_type\",          \"type\": \"Byte\",   \"default\": \"-1\"},\n        {\"id\": 6,\"name\": \"attribution_results\",\"type\": \"List:attribution_result\"},\n        {\"id\": 7,\"name\": \"allowed_ad_formats\",\"type\": \"Long\",   \"default\": \"-1\"},\n\t\t{\"id\": 8,\"name\": \"cost\",\"type\": \"Double\",   \"default\": \"0\"}\n\t\t]\n    },\n    {\n      \"table\": \"provider_user_id\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"provider_type\",          \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"provider_id\",            \"type\": \"Integer\",\"isRequired\": true}\n      ]\n    },\n    {\n      \"table\": \"id_map\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"media_provider_ids\",\"type\": \"List:provider_user_id\"}\n      ]\n    },\n    {\n      \"table\": \"analytical_user_profile\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"user_id\",                 \"type\": \"Long\",   \"isRequired\": true, \"isFrequentlyUsed\": true},\n        {\"id\": 2,\"name\": \"version\",         \"type\": \"Byte\", \"isRequired\": true, \"isDesSortKey\": true},\n        {\"id\": 3,\"name\": \"resolution\",      \"type\": \"Short\",  \"default\": \"-1\"},\n        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\n        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\n        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\n\t\t{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"}\n      ]\n    }\n  ]\n}";
+		String json_schema = "{\r\n" + 
+				"  \"schema\": \"simple_schema\",\r\n" + 
+				"  \"table_list\": [\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"attribution_result_rule\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"default\": \"Unknown\"}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"attribution_result\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"id\",\"type\": \"Integer\",\"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"rules\",      \"type\": \"List:attribution_result_rule\", \"isRequired\": true}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"impression\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1, \"name\": \"media_provider_id\", \"type\": \"Integer\",\"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"mp_tpt_category_id\",\"type\": \"Short\",  \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 3,\"name\": \"truncated_url\",     \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
+				"        {\"id\": 4,\"name\": \"bid\",         \"type\": \"Boolean\",  \"default\": \"true\"},\r\n" + 
+				"        {\"id\": 5,\"name\": \"bid_type\",          \"type\": \"Byte\",   \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 6,\"name\": \"attribution_results\",\"type\": \"List:attribution_result\"},\r\n" + 
+				"        {\"id\": 7,\"name\": \"allowed_ad_formats\",\"type\": \"Long\",   \"default\": \"-1\"},\r\n" + 
+				"		{\"id\": 8,\"name\": \"cost\",\"type\": \"Double\",   \"default\": \"0\"}\r\n" + 
+				"		]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"provider_user_id\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"provider_type\",          \"type\": \"Byte\",   \"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"provider_id\",            \"type\": \"Integer\",\"isRequired\": true}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"id_map\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"media_provider_ids\",\"type\": \"List:provider_user_id\"}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"analytical_user_profile\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"user_id\",                 \"type\": \"Integer\",   \"isRequired\": true, \"isFrequentlyUsed\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"version\",         \"type\": \"Byte\", \"isRequired\": true, \"isDesSortKey\": true},\r\n" + 
+				"        {\"id\": 3,\"name\": \"resolution\",      \"type\": \"Short\",  \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
+				"        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\r\n" + 
+				"        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\r\n" + 
+				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"},\r\n" + 
+				"		{\"id\": 8, \"name\": \"data\",     \"type\": \"Binary\"},\r\n" + 
+				"		{\"id\": 0, \"name\": \"day\",     \"type\": \"String\", \"isDerived\": true, \"default\": \"Unknown\"}\r\n" + 
+				"      ]\r\n" + 
+				"    }\r\n" + 
+				"  ]\r\n" + 
+				"}\r\n" + 
+				"";
+		
 		Schema nextSchema = new JsonSchemaConvertor().apply(json_schema);
 		SchemaEvolutionValidation validate = 
 				new SchemaEvolutionValidation(currentSchema);
@@ -77,7 +261,66 @@ public class SchemaEvolutionValidationTest {
 	
 	@Test(expectedExceptions = FieldDefaultValueModifiedInSchemaEvolutionException.class)
 	public void checkFieldDefaultValueChangedSchema() throws AbstractValidationException {
-		String json_schema = "{\n  \"schema\": \"simple_schema\",\n  \"table_list\": [\n    {\n      \"table\": \"attribution_result_rule\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"default\": \"Unknown\"}\n      ]\n    },\n    {\n      \"table\": \"attribution_result\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"id\",\"type\": \"Integer\",\"isRequired\": true},\n        {\"id\": 2,\"name\": \"rules\",      \"type\": \"List:attribution_result_rule\", \"isRequired\": true}\n      ]\n    },\n    {\n      \"table\": \"impression\",\n      \"fields\": [\n        {\"id\": 1, \"name\": \"media_provider_id\", \"type\": \"Integer\",\"isRequired\": true},\n        {\"id\": 2,\"name\": \"mp_tpt_category_id\",\"type\": \"Short\",  \"default\": \"-1\"},\n        {\"id\": 3,\"name\": \"truncated_url\",     \"type\": \"String\", \"default\": \"Unknown\"},\n        {\"id\": 4,\"name\": \"bid\",         \"type\": \"Boolean\",  \"default\": \"false\"},\n        {\"id\": 5,\"name\": \"bid_type\",          \"type\": \"Byte\",   \"default\": \"-1\"},\n        {\"id\": 6,\"name\": \"attribution_results\",\"type\": \"List:attribution_result\"},\n        {\"id\": 7,\"name\": \"allowed_ad_formats\",\"type\": \"Long\",   \"default\": \"-1\"},\n\t\t{\"id\": 8,\"name\": \"cost\",\"type\": \"Double\",   \"default\": \"0\"}\n\t\t]\n    },\n    {\n      \"table\": \"provider_user_id\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"provider_type\",          \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"provider_id\",            \"type\": \"Integer\",\"isRequired\": true}\n      ]\n    },\n    {\n      \"table\": \"id_map\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"media_provider_ids\",\"type\": \"List:provider_user_id\"}\n      ]\n    },\n    {\n      \"table\": \"analytical_user_profile\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"user_id\",                 \"type\": \"Long\",   \"isRequired\": true, \"isFrequentlyUsed\": true},\n        {\"id\": 2,\"name\": \"version\",         \"type\": \"Byte\", \"isRequired\": true, \"isDesSortKey\": true},\n        {\"id\": 3,\"name\": \"resolution\",      \"type\": \"Short\",  \"default\": \"-1\"},\n        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\n        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\n        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\n\t\t{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"}\n      ]\n    }\n  ]\n}";
+		String json_schema = "{\r\n" + 
+				"  \"schema\": \"simple_schema\",\r\n" + 
+				"  \"table_list\": [\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"attribution_result_rule\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"default\": \"Unknown\"}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"attribution_result\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"id\",\"type\": \"Integer\",\"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"rules\",      \"type\": \"List:attribution_result_rule\", \"isRequired\": true}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"impression\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1, \"name\": \"media_provider_id\", \"type\": \"Integer\",\"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"mp_tpt_category_id\",\"type\": \"Short\",  \"default\": \"100\"},\r\n" + 
+				"        {\"id\": 3,\"name\": \"truncated_url\",     \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
+				"        {\"id\": 4,\"name\": \"bid\",         \"type\": \"Boolean\",  \"default\": \"true\"},\r\n" + 
+				"        {\"id\": 5,\"name\": \"bid_type\",          \"type\": \"Byte\",   \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 6,\"name\": \"attribution_results\",\"type\": \"List:attribution_result\"},\r\n" + 
+				"        {\"id\": 7,\"name\": \"allowed_ad_formats\",\"type\": \"Long\",   \"default\": \"-1\"},\r\n" + 
+				"		{\"id\": 8,\"name\": \"cost\",\"type\": \"Double\",   \"default\": \"0\"}\r\n" + 
+				"		]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"provider_user_id\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"provider_type\",          \"type\": \"Byte\",   \"isRequired\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"provider_id\",            \"type\": \"Integer\",\"isRequired\": true}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"id_map\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"media_provider_ids\",\"type\": \"List:provider_user_id\"}\r\n" + 
+				"      ]\r\n" + 
+				"    },\r\n" + 
+				"    {\r\n" + 
+				"      \"table\": \"analytical_user_profile\",\r\n" + 
+				"      \"fields\": [\r\n" + 
+				"        {\"id\": 1,\"name\": \"user_id\",                 \"type\": \"Long\",   \"isRequired\": true, \"isFrequentlyUsed\": true},\r\n" + 
+				"        {\"id\": 2,\"name\": \"version\",         \"type\": \"Byte\", \"isRequired\": true, \"isDesSortKey\": true},\r\n" + 
+				"        {\"id\": 3,\"name\": \"resolution\",      \"type\": \"Short\",  \"default\": \"-1\"},\r\n" + 
+				"        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
+				"        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\r\n" + 
+				"        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\r\n" + 
+				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"},\r\n" + 
+				"		{\"id\": 8, \"name\": \"data\",     \"type\": \"Binary\"},\r\n" + 
+				"		{\"id\": 0, \"name\": \"day\",     \"type\": \"String\", \"isDerived\": true, \"default\": \"Unknown\"}\r\n" + 
+				"      ]\r\n" + 
+				"    }\r\n" + 
+				"  ]\r\n" + 
+				"}\r\n";
+		
 		Schema nextSchema = new JsonSchemaConvertor().apply(json_schema);
 		SchemaEvolutionValidation validate = 
 				new SchemaEvolutionValidation(currentSchema);
@@ -138,7 +381,8 @@ public class SchemaEvolutionValidationTest {
 				"        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
 				"        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\r\n" + 
 				"        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\r\n" + 
-				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"}\r\n" + 
+				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"},\r\n" + 
+				"		{\"id\": 8, \"name\": \"data\",     \"type\": \"Binary\"}\r\t" + 
 				"      ]\r\n" + 
 				"    }\r\n" + 
 				"  ]\r\n" + 
@@ -203,7 +447,8 @@ public class SchemaEvolutionValidationTest {
 				"        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
 				"        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\r\n" + 
 				"        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\r\n" + 
-				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"}\r\n" + 
+				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"},\r\n" + 
+				"		{\"id\": 8, \"name\": \"data\",     \"type\": \"Binary\"}\r\t" +
 				"      ]\r\n" + 
 				"    }\r\n" + 
 				"  ]\r\n" + 
@@ -268,7 +513,8 @@ public class SchemaEvolutionValidationTest {
 				"        {\"id\": 4,\"name\": \"os_version\",      \"type\": \"String\", \"default\": \"Unknown\"},\r\n" + 
 				"        {\"id\": 5,\"name\": \"impressions\",            \"type\": \"List:impression\"},\r\n" + 
 				"        {\"id\": 6,\"name\": \"id_maps\",                \"type\": \"id_map\"},\r\n" + 
-				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"}\r\n" + 
+				"		{\"id\": 7, \"name\": \"time_list\",     \"type\": \"List:Integer\"},\r\n" +
+				"		{\"id\": 8, \"name\": \"data\",     \"type\": \"Binary\"}\r\n" +
 				"      ]\r\n" + 
 				"    }\r\n" + 
 				"  ]\r\n" + 

--- a/RecordBuffers/src/test/java/datamine/storage/idl/validate/SchemaValidationTest.java
+++ b/RecordBuffers/src/test/java/datamine/storage/idl/validate/SchemaValidationTest.java
@@ -19,11 +19,9 @@ import org.testng.annotations.Test;
 
 import datamine.storage.idl.Schema;
 import datamine.storage.idl.json.JsonSchemaConvertor;
-import datamine.storage.idl.validate.SchemaValidation;
 import datamine.storage.idl.validate.exceptions.AbstractValidationException;
 import datamine.storage.idl.validate.exceptions.IdentityDuplicationException;
 import datamine.storage.idl.validate.exceptions.IllegalDerivedFieldException;
-import datamine.storage.idl.validate.exceptions.IllegalFieldDefaultValueException;
 import datamine.storage.idl.validate.exceptions.IllegalFieldIdentityException;
 import datamine.storage.idl.validate.exceptions.IllegalNamingConversionException;
 import datamine.storage.idl.validate.exceptions.IllegalTableVersionException;
@@ -90,7 +88,7 @@ public class SchemaValidationTest {
 	
 	@Test(expectedExceptions = IllegalDerivedFieldException.class)
 	public void checkDerivedFieldMustBePrimitive() throws AbstractValidationException {
-		String json_str = "{\n  \"schema\": \"simple_schema\",\n  \"table_list\": [\n    {\n      \"table\": \"attribution_result_rule\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"isRequired\": true, \"isAscSortKey\": true},\n        {\"id\": 0,\"name\": \"key\",      \"type\": \"List:Integer\", \"default\": \"Unknown\", \"isDerived\": true}\n      ]\n    }\n    ]\n}";
+		String json_str = "{\n  \"schema\": \"simple_schema\",\n  \"table_list\": [\n    {\n      \"table\": \"attribution_result_rule\",\n      \"fields\": [\n        {\"id\": 1,\"name\": \"run_num\",    \"type\": \"Byte\",   \"isRequired\": true},\n        {\"id\": 2,\"name\": \"value\",      \"type\": \"String\", \"isRequired\": true, \"isAscSortKey\": true},\n        {\"id\": 0,\"name\": \"key\",      \"type\": \"List:Integer\", \"isDerived\": true}\n      ]\n    }\n    ]\n}";
 		Schema schema = new JsonSchemaConvertor().apply(json_str);
 		new SchemaValidation().check(schema);
 	}

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/convertors/AnalyticalUserProfileInterfaceConvertor.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/convertors/AnalyticalUserProfileInterfaceConvertor.java
@@ -58,6 +58,8 @@ public class AnalyticalUserProfileInterfaceConvertor implements UnaryOperatorInt
 		}
 		output.setTimeList(input.getTimeList());
 
+		output.setData(input.getData());
+
 
 		return output;
 	}

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/AnalyticalUserProfileTestData.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/AnalyticalUserProfileTestData.java
@@ -75,6 +75,10 @@ public class AnalyticalUserProfileTestData extends AbstractTestData<AnalyticalUs
 				record.setTimeList((List) cur.get(AnalyticalUserProfileMetadata.TIME_LIST));
 			}
 
+			if (cur.containsKey(AnalyticalUserProfileMetadata.DATA)) {
+				record.setData((byte[]) cur.get(AnalyticalUserProfileMetadata.DATA));
+			}
+
 			records.add(record);
 		}
 		return records;
@@ -112,6 +116,10 @@ public class AnalyticalUserProfileTestData extends AbstractTestData<AnalyticalUs
 
 			if (data.get(i).containsKey(AnalyticalUserProfileMetadata.TIME_LIST)) {
 				Assert.assertEquals((List) objectList.get(i).getTimeList(), data.get(i).get(AnalyticalUserProfileMetadata.TIME_LIST));
+			}
+
+			if (data.get(i).containsKey(AnalyticalUserProfileMetadata.DATA)) {
+				Assert.assertEquals(objectList.get(i).getData(), data.get(i).get(AnalyticalUserProfileMetadata.DATA));
 			}
 
 			if (data.get(i).containsKey(AnalyticalUserProfileMetadata.DAY)) {
@@ -172,6 +180,13 @@ public class AnalyticalUserProfileTestData extends AbstractTestData<AnalyticalUs
 				Object val = RandomValueGenerator.getValueArrayOf(((PrimitiveFieldType) ((CollectionFieldType)AnalyticalUserProfileMetadata.TIME_LIST.getField().getType()).getElementType()).getType(), num);
 				if (val != null && !((List) val).isEmpty()) {
 					dataMap.put(AnalyticalUserProfileMetadata.TIME_LIST, val);
+				}
+			}
+
+			{
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.DATA.getField().getType()).getType());
+				if (val != null) {
+					dataMap.put(AnalyticalUserProfileMetadata.DATA, val);
 				}
 			}
 

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/interfaces/AnalyticalUserProfileInterface.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/interfaces/AnalyticalUserProfileInterface.java
@@ -32,6 +32,7 @@ public interface AnalyticalUserProfileInterface extends BaseInterface , Comparab
 		public List<ImpressionInterface> getImpressions();
 		public IdMapInterface getIdMaps();
 		public List<Integer> getTimeList();
+		public byte[] getData();
 		public String getDay();
 
 		public void setUserId(long input);
@@ -41,6 +42,7 @@ public interface AnalyticalUserProfileInterface extends BaseInterface , Comparab
 		public void setImpressions(List<ImpressionInterface> input);
 		public void setIdMaps(IdMapInterface input);
 		public void setTimeList(List<Integer> input);
+		public void setData(byte[] input);
 
 		public long getUserIdDefaultValue();
 		public byte getVersionDefaultValue();

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/model/AnalyticalUserProfileMetadata.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/model/AnalyticalUserProfileMetadata.java
@@ -35,6 +35,7 @@ public enum AnalyticalUserProfileMetadata implements RecordMetadataInterface {
 	IMPRESSIONS((short)5, "impressions", FieldTypeFactory.getListType(FieldTypeFactory.getGroupType(ImpressionMetadata.class)), false, null, false, false, false, false),
 	ID_MAPS((short)6, "id_maps", FieldTypeFactory.getGroupType(IdMapMetadata.class), false, null, false, false, false, false),
 	TIME_LIST((short)7, "time_list", FieldTypeFactory.getListType(FieldTypeFactory.getPrimitiveType(PrimitiveType.INT32)), false, null, false, false, false, false),
+	DATA((short)8, "data", FieldTypeFactory.getPrimitiveType(PrimitiveType.BINARY), false, null, false, false, false, false),
 	DAY((short)0, "day", FieldTypeFactory.getPrimitiveType(PrimitiveType.STRING), false, (String)"Unknown", false, false, false, true),
 ;
 

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/AnalyticalUserProfileRecord.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/AnalyticalUserProfileRecord.java
@@ -167,6 +167,12 @@ public class AnalyticalUserProfileRecord implements AnalyticalUserProfileInterfa
     }
 
     @Override
+    public byte[] getData() {
+        
+        return this.value.getBinary(AnalyticalUserProfileMetadata.DATA);
+    }
+
+    @Override
     public String getDay() {
         
         return derivedFieldValues.getDay();
@@ -251,6 +257,15 @@ public class AnalyticalUserProfileRecord implements AnalyticalUserProfileInterfa
 		this.value.setValue(AnalyticalUserProfileMetadata.TIME_LIST, list);
 
 			
+		}
+	}
+
+
+	@Override
+	public void setData(byte[] input) {
+		if (1 == 1) {
+			
+			this.value.setValue(AnalyticalUserProfileMetadata.DATA, input);
 		}
 	}
 

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/AttributionResultRecord.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/AttributionResultRecord.java
@@ -73,7 +73,7 @@ public class AttributionResultRecord implements AttributionResultInterface {
 
     @Override
     public void copyFrom(BaseInterface right) {
-		// note that it may not be deep copy!!
+		// note that it must be deep copy!!
 		this.value = new WritableRecord<AttributionResultMetadata>(AttributionResultMetadata.class, 
 			new RecordBuffer(((Record) right.getBaseObject()).getRecordBuffer()));
     }

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/AttributionResultRuleRecord.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/AttributionResultRuleRecord.java
@@ -73,7 +73,7 @@ public class AttributionResultRuleRecord implements AttributionResultRuleInterfa
 
     @Override
     public void copyFrom(BaseInterface right) {
-		// note that it may not be deep copy!!
+		// note that it must be deep copy!!
 		this.value = new WritableRecord<AttributionResultRuleMetadata>(AttributionResultRuleMetadata.class, 
 			new RecordBuffer(((Record) right.getBaseObject()).getRecordBuffer()));
     }

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/IdMapRecord.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/IdMapRecord.java
@@ -73,7 +73,7 @@ public class IdMapRecord implements IdMapInterface {
 
     @Override
     public void copyFrom(BaseInterface right) {
-		// note that it may not be deep copy!!
+		// note that it must be deep copy!!
 		this.value = new WritableRecord<IdMapMetadata>(IdMapMetadata.class, 
 			new RecordBuffer(((Record) right.getBaseObject()).getRecordBuffer()));
     }

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/ImpressionRecord.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/ImpressionRecord.java
@@ -73,7 +73,7 @@ public class ImpressionRecord implements ImpressionInterface {
 
     @Override
     public void copyFrom(BaseInterface right) {
-		// note that it may not be deep copy!!
+		// note that it must be deep copy!!
 		this.value = new WritableRecord<ImpressionMetadata>(ImpressionMetadata.class, 
 			new RecordBuffer(((Record) right.getBaseObject()).getRecordBuffer()));
     }

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/ProviderUserIdRecord.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/ProviderUserIdRecord.java
@@ -73,7 +73,7 @@ public class ProviderUserIdRecord implements ProviderUserIdInterface {
 
     @Override
     public void copyFrom(BaseInterface right) {
-		// note that it may not be deep copy!!
+		// note that it must be deep copy!!
 		this.value = new WritableRecord<ProviderUserIdMetadata>(ProviderUserIdMetadata.class, 
 			new RecordBuffer(((Record) right.getBaseObject()).getRecordBuffer()));
     }

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/builder/RecordBuffersBuilder.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/builder/RecordBuffersBuilder.java
@@ -39,8 +39,8 @@ public class RecordBuffersBuilder implements RecordBuilderInterface {
 
 		try {
 			
-		if (tableClass == IdMapInterface.class) {
-			return (T) IdMapRecord.class.newInstance();
+		if (tableClass == AttributionResultInterface.class) {
+			return (T) AttributionResultRecord.class.newInstance();
 		}
 		else
 		if (tableClass == ImpressionInterface.class) {
@@ -51,16 +51,16 @@ public class RecordBuffersBuilder implements RecordBuilderInterface {
 			return (T) AnalyticalUserProfileRecord.class.newInstance();
 		}
 		else
-		if (tableClass == AttributionResultInterface.class) {
-			return (T) AttributionResultRecord.class.newInstance();
+		if (tableClass == ProviderUserIdInterface.class) {
+			return (T) ProviderUserIdRecord.class.newInstance();
 		}
 		else
 		if (tableClass == AttributionResultRuleInterface.class) {
 			return (T) AttributionResultRuleRecord.class.newInstance();
 		}
 		else
-		if (tableClass == ProviderUserIdInterface.class) {
-			return (T) ProviderUserIdRecord.class.newInstance();
+		if (tableClass == IdMapInterface.class) {
+			return (T) IdMapRecord.class.newInstance();
 		}
 
 		} catch (InstantiationException e) {

--- a/RecordBuffers/src/test/resources/SimpleSchema.json
+++ b/RecordBuffers/src/test/resources/SimpleSchema.json
@@ -51,6 +51,7 @@
         {"id": 5,"name": "impressions",            "type": "List:impression"},
         {"id": 6,"name": "id_maps",                "type": "id_map"},
 		{"id": 7, "name": "time_list",     "type": "List:Integer"},
+		{"id": 8, "name": "data",     "type": "Binary"},
 		{"id": 0, "name": "day",     "type": "String", "isDerived": true, "default": "Unknown"}
       ]
     }


### PR DESCRIPTION
1. Enabled the binary type attribute in the schema definition (issue: #9)
2. Changed the unit test by adding a binary type attribute
3. Fixed a bug with the Record implementation to make sure the size of a non-fixed-lenght attribute value is written in the record buffer even if it is zero.

Signed-off-by: Yan Qi yan.qi.asu@gmail.com
