### PR TITLE
Enable the reading performance profiling

### DIFF
--- a/RecordBuffers/src/main/java/datamine/storage/idl/validate/exceptions/TableUndefinedException.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/validate/exceptions/TableUndefinedException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Turn Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package datamine.storage.idl.validate.exceptions;
+
+/**
+ * @author yqi
+ */
+public class TableUndefinedException extends AbstractValidationException {
+
+	private static final long serialVersionUID = 3812117802751276493L;
+	private static final String MSG_PATTERN = 
+			"Cannot find the table definition: %s!";
+		
+	public TableUndefinedException(String tableName) {
+		super(String.format(MSG_PATTERN, tableName));
+	}
+	
+}

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/ReadOnlyRecord.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/ReadOnlyRecord.java
@@ -109,6 +109,14 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 	@Override
 	public Object getValue(T col) {
 	
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
+		}
+		
 		Field field = col.getField();
 		FieldType type = field.getType();
 		FieldValueOperatorInterface valueOpr = FieldValueOperatorFactory.getOperator(type);
@@ -131,6 +139,13 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 			result = valueOpr.getValue(buf, offset + 4, buf.getInt(offset));
 		} 
 		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
 		// never return NULL
 		if (result == null) { 
 			return col.getField().getDefaultValue();
@@ -140,97 +155,260 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 	}
 	
 	public boolean getBool(T col) {
-		int offset = getOffset(col);
-		if (offset > 0) {
-			return buffer.getByteBuffer().get(offset) == 1 ? true : false;
-		} else {
-			return (Boolean) col.getField().getDefaultValue();
+		
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
 		}
+		
+		int offset = getOffset(col);
+		boolean result;
+		if (offset > 0) {
+			result = buffer.getByteBuffer().get(offset) == 1 ? true : false;
+		} else {
+			result = (Boolean) col.getField().getDefaultValue();
+		}
+		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
+		return result;
 	}
 
 	
 	public byte getByte(T col) {
-		int offset = getOffset(col);
-		if (offset > 0) {
-			return buffer.getByteBuffer().get(offset);
-		} else {
-			return (Byte) col.getField().getDefaultValue();
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
 		}
+		
+		int offset = getOffset(col);
+		byte result;
+		if (offset > 0) {
+			result = buffer.getByteBuffer().get(offset);
+		} else {
+			result = (Byte) col.getField().getDefaultValue();
+		}
+		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
+		return result;
 	}
 
 	
 	public short getShort(T col) {
-		int offset = getOffset(col);
-		if (offset > 0) {
-			return buffer.getByteBuffer().getShort(offset);
-		} else {
-			return (Short) col.getField().getDefaultValue();
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
 		}
+		
+		int offset = getOffset(col);
+		short result;
+		if (offset > 0) {
+			result = buffer.getByteBuffer().getShort(offset);
+		} else {
+			result = (Short) col.getField().getDefaultValue();
+		}
+		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
+		return result;
 	}
 
 	
 	public long getLong(T col) {
-		int offset = getOffset(col);
-		if (offset > 0) {
-			return buffer.getByteBuffer().getLong(offset);
-		} else {
-			return (Long) col.getField().getDefaultValue();
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
 		}
+		
+		int offset = getOffset(col);
+		long result;
+		if (offset > 0) {
+			result = buffer.getByteBuffer().getLong(offset);
+		} else {
+			result = (Long) col.getField().getDefaultValue();
+		}
+		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
+		return result;
 	}
 
 	
 	public int getInt(T col) {
-		int offset = getOffset(col);
-		if (offset > 0) {
-			return buffer.getByteBuffer().getInt(offset);
-		} else {
-			return (Integer) col.getField().getDefaultValue();
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
 		}
+		
+		int offset = getOffset(col);
+		int result;
+		if (offset > 0) {
+			result = buffer.getByteBuffer().getInt(offset);
+		} else {
+			result = (Integer) col.getField().getDefaultValue();
+		}
+		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
+		return result;
 	}
 
 	
 	public float getFloat(T col) {
-		int offset = getOffset(col);
-		if (offset > 0) {
-			return buffer.getByteBuffer().getFloat(offset);
-		} else {
-			return (Float) col.getField().getDefaultValue();
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
 		}
+		
+		int offset = getOffset(col);
+		float result;
+		if (offset > 0) {
+			result = buffer.getByteBuffer().getFloat(offset);
+		} else {
+			result = (Float) col.getField().getDefaultValue();
+		}
+		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
+		return result;
 	}
 
 	
 	public double getDouble(T col) {
-		int offset = getOffset(col);
-		if (offset > 0) {
-			return buffer.getByteBuffer().getDouble(offset);
-		} else {
-			return (Double) col.getField().getDefaultValue();
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
 		}
+		
+		int offset = getOffset(col);
+		double result;
+		if (offset > 0) {
+			result = buffer.getByteBuffer().getDouble(offset);
+		} else {
+			result = (Double) col.getField().getDefaultValue();
+		}
+		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
+		return result;
 	}
 
 	
 	public byte[] getBinary(T col) {
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
+		}
+		
 		int offset = getOffset(col);
+		byte[] result;
 		if (offset > 0) {
 			int length = buffer.getByteBuffer().getInt(offset);
 			byte[] out = new byte[length];
 			byte[] src = buffer.getByteBuffer().array();
 			System.arraycopy(src, offset + 4, out, 0, length);
-			return out;
+			result = out;
 		} else {
-			return (byte[]) col.getField().getDefaultValue();
+			result = (byte[]) col.getField().getDefaultValue();
 		}
+		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
+		return result;
 	}
 
 	
 	public String getString(T col) {
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
+		}
+		
 		int offset = getOffset(col);
+		String result;
 		if (offset > 0) {
 			int length = buffer.getByteBuffer().getShort(offset);
-			return new String(buffer.getByteBuffer().array(), offset + 2, length);
+			result = new String(buffer.getByteBuffer().array(), offset + 2, length);
 		} else {
-			return (String) col.getField().getDefaultValue();
+			result = (String) col.getField().getDefaultValue();
 		}
+		
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+		
+		return result;
 	}
 	
 	/**

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/Record.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/Record.java
@@ -25,7 +25,25 @@ import datamine.storage.api.RecordMetadataInterface;
  * @author yqi
  */
 public abstract class Record<T extends Enum<T> & RecordMetadataInterface> {
-		
+	
+	/**
+	 * Static members for the performance profiling
+	 */
+	protected static final boolean IS_DEBUG_ENABLED = true;
+	protected static int recursionLevel = 0;
+	protected static long readingTimeCostMiliSeconds = 0;
+	
+	public static void clearTimeCostCounter() {
+		if (IS_DEBUG_ENABLED) {
+			recursionLevel = 0;
+			readingTimeCostMiliSeconds = 0;
+		}
+	}
+	
+	public static long getTimeCostInMilliSecond() {
+		return readingTimeCostMiliSeconds;
+	}
+	
 	/**
 	 * The storage metadata about the recordbuffer is final
 	 */

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
@@ -126,6 +126,14 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 	@Override
 	public Object getValue(T col) {
 	
+		long ts = 0;
+		if (IS_DEBUG_ENABLED) {
+			if (recursionLevel == 0) {
+				ts = System.currentTimeMillis();
+			}
+			recursionLevel++;
+		}
+		
 		if (valueArray == null && readOnlyRecord == null && buffer != null) {
 			readOnlyRecord = new ReadOnlyRecord<T>(meta.getTableEnumClass(), buffer);
 		}
@@ -137,6 +145,14 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 		Field field = col.getField();
 		int id = field.getId() - 1; // note that id starts at 1.
  		Object result = valueArray != null && valueArray.length > id ? valueArray[id] : null;
+ 		
+ 		if (IS_DEBUG_ENABLED) {
+ 			recursionLevel--;
+			if (recursionLevel == 0) {
+				readingTimeCostMiliSeconds += System.currentTimeMillis() - ts;
+			} 
+		}
+ 		
 		if (result == null) { // never return NULL
 			return col.getField().getDefaultValue();
 		} else {


### PR DESCRIPTION
Added 3 static members in Record.java to make it possible to profile the
reading performance of recordbuffers.

Solved the issue of #11 
