### PR TITLE
Changed back about the value length

### DIFF
--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/ReadOnlyRecord.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/ReadOnlyRecord.java
@@ -309,14 +309,14 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 					case STRING:
 						// string requires a SHORT to store its length (max < 32k)
 						short arrayLength = bytebuffer.getShort(offset);
-						if (arrayLength >= 0) {
+						if (arrayLength > 0) {
 							offset += 2 + arrayLength;	
 						}
 						break;
 					case BINARY:
 						// other types require a INT to store its length info
 						int arrayLength2 = bytebuffer.getInt(offset);
-						if (arrayLength2 >= 0) {
+						if (arrayLength2 > 0) {
 							offset += 4 + arrayLength2;	
 						}
 						break;
@@ -327,12 +327,12 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 					}
 				} else if (fieldType instanceof GroupFieldType) {
 					int arrayLength2 = bytebuffer.getInt(offset);
-					if (arrayLength2 >= 0) {
+					if (arrayLength2 > 0) {
 						offset += 4 + arrayLength2;	
 					}
 				} else if (fieldType instanceof CollectionFieldType) {
 					int arrayLength2 = bytebuffer.getInt(offset);
-					if (arrayLength2 >= 0) {
+					if (arrayLength2 > 0) {
 						offset += 4 + arrayLength2;	
 					}
 				}

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
@@ -269,7 +269,7 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 					case STRING:
 						// string requires a SHORT to store its length (max < 32k)
 						short arrayLength = bytebuffer.getShort(offset);
-						if (arrayLength >= 0) {
+						if (arrayLength > 0) {
 							valueArray[id] = valueOpr.getValue(bytebuffer, offset + 2, arrayLength);
 							offset += 2 + arrayLength;	
 						}
@@ -277,7 +277,7 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 					case BINARY:
 						// other types require a INT to store its length info
 						int arrayLength2 = bytebuffer.getInt(offset);
-						if (arrayLength2 >= 0) {
+						if (arrayLength2 > 0) {
 							valueArray[id] = valueOpr.getValue(bytebuffer, offset + 4, arrayLength2);
 							offset += 4 + arrayLength2;	
 						}
@@ -411,7 +411,7 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 							!curField.equalToDefaultValue(val)) {
 
 						byte[] byteArray = valOpr.getByteArray(val);
-						if (byteArray.length >= 0) { // a dummy '0' must be written even if it has no value
+						if (byteArray.length > 0) {
 
 							hasValidValue = true;
 


### PR DESCRIPTION
The zero-length value has been treated specially, so it is not necessary to change the checking conditions.
