### PR TITLE
Rename the getter functions for value type

### DIFF
--- a/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/InterfaceConvertorGenerator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/InterfaceConvertorGenerator.java
@@ -165,7 +165,7 @@ public class InterfaceConvertorGenerator implements ElementVisitor, CodeGenerato
 			};
 			
 			CodeTemplate fieldCode = null;
-			if (type.getType() == CollectionType.LIST) {
+			if (type.getCollectionType() == CollectionType.LIST) {
 				FieldType elementType = type.getElementType();
 				if (elementType instanceof PrimitiveFieldType) {
 					fieldCode = createPrimitiveFieldTypeTemplate((PrimitiveFieldType) elementType);
@@ -181,7 +181,7 @@ public class InterfaceConvertorGenerator implements ElementVisitor, CodeGenerato
 				
 			} else {
 				throw new IllegalArgumentException("Not support the type of " +
-						((CollectionFieldType) type).getType());
+						((CollectionFieldType) type).getCollectionType());
 			}
 			return fieldCode;
 		}

--- a/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/InterfaceGenerator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/InterfaceGenerator.java
@@ -129,17 +129,17 @@ public class InterfaceGenerator implements CodeGenerator, ElementVisitor {
 		
 		// generate get list size for list field
 		if (type instanceof CollectionFieldType) {
-			if (((CollectionFieldType) type).getType() == CollectionType.LIST) {
+			if (((CollectionFieldType) type).getCollectionType() == CollectionType.LIST) {
 				currentTemplate.fillFields("fieldListSize", 
 						templateGenerator.getListSizeTemplate());	
 			} else {
 				throw new IllegalArgumentException("Not support the type of " + 
-						((CollectionFieldType) type).getType());
+						((CollectionFieldType) type).getCollectionType());
 			}
 		}
 		
 		//generate getDefault function only for primitive field
-		if (type instanceof PrimitiveFieldType && ((PrimitiveFieldType) type).getType() != PrimitiveType.BINARY) {
+		if (type instanceof PrimitiveFieldType && ((PrimitiveFieldType) type).getPrimitiveType() != PrimitiveType.BINARY) {
 			currentTemplate.fillFields("fieldDefaultValue", 
 					templateGenerator.getDefaultValueTemplate());
 		}
@@ -203,7 +203,7 @@ public class InterfaceGenerator implements CodeGenerator, ElementVisitor {
 	public static String getGetterName(Field field) {
 		FieldType type = field.getType();
 		if (type instanceof PrimitiveFieldType &&
-		    ((PrimitiveFieldType) type).getType() == PrimitiveType.BOOL) {
+		    ((PrimitiveFieldType) type).getPrimitiveType() == PrimitiveType.BOOL) {
 			return new StringBuilder().append("is").append(CaseFormat.LOWER_UNDERSCORE
 					.to(CaseFormat.UPPER_CAMEL, field.getName())).toString();
 		}

--- a/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/JavaTypeConvertor.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/JavaTypeConvertor.java
@@ -42,7 +42,7 @@ public class JavaTypeConvertor implements UnaryOperatorInterface<FieldType, Stri
 	
 	private String convert(PrimitiveFieldType type) {
 		String javaType = "";
-		switch (type.getType()) {
+		switch (type.getPrimitiveType()) {
 		case BOOL:
 			javaType = useBoxing ? "Boolean" : "boolean";
 			break;
@@ -71,7 +71,7 @@ public class JavaTypeConvertor implements UnaryOperatorInterface<FieldType, Stri
 			javaType = "byte[]";
 			break;
 		default:
-			throw new IllegalArgumentException("Not support the type: "+type.getType());
+			throw new IllegalArgumentException("Not support the type: "+type.getPrimitiveType());
 		}
 		return javaType;
 	}
@@ -86,14 +86,14 @@ public class JavaTypeConvertor implements UnaryOperatorInterface<FieldType, Stri
 	
 	private String convert(CollectionFieldType type) {
 		StringBuilder sb = new StringBuilder();
-		if (type.getType() == CollectionType.LIST) {
+		if (type.getCollectionType() == CollectionType.LIST) {
 			useBoxing = true;
 			sb.append("List<");
 			sb.append(apply(type.getElementType()));
 			sb.append(">");
 			useBoxing = false;
 		} else {
-			throw new IllegalArgumentException("Not support "+type.getType());
+			throw new IllegalArgumentException("Not support "+type.getCollectionType());
 		}
 		return sb.toString();
 	}

--- a/RecordBuffers/src/main/java/datamine/storage/idl/generator/metadata/MetaTypeConvertor.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/generator/metadata/MetaTypeConvertor.java
@@ -31,7 +31,7 @@ public class MetaTypeConvertor implements UnaryOperatorInterface<FieldType, Stri
 	
 	private String convert(PrimitiveFieldType type) {
 		String typeFormat = "FieldTypeFactory.getPrimitiveType(PrimitiveType.%s)";
-		switch (type.getType()) {
+		switch (type.getPrimitiveType()) {
 		case BOOL:
 			return String.format(typeFormat, "BOOL");
 		case BYTE:
@@ -51,7 +51,7 @@ public class MetaTypeConvertor implements UnaryOperatorInterface<FieldType, Stri
 		case BINARY:
 			return String.format(typeFormat, "BINARY");
 		default:
-			throw new IllegalArgumentException("Not support the type: "+type.getType());
+			throw new IllegalArgumentException("Not support the type: "+type.getPrimitiveType());
 		}
 	}
 	

--- a/RecordBuffers/src/main/java/datamine/storage/idl/generator/metadata/MetadataFileGenerator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/generator/metadata/MetadataFileGenerator.java
@@ -160,7 +160,7 @@ public class MetadataFileGenerator implements ElementVisitor,
 		FieldType type = field.getType();
 		// the field does not have the default unless it is optional and primitive
 		if (field.isRequired() || !(type instanceof PrimitiveFieldType) ||
-			(type instanceof PrimitiveFieldType && ((PrimitiveFieldType)type).getType() == PrimitiveType.BINARY)) {
+			(type instanceof PrimitiveFieldType && ((PrimitiveFieldType)type).getPrimitiveType() == PrimitiveType.BINARY)) {
 			sb.append("null"); // default value
 			
 		} else {
@@ -168,7 +168,7 @@ public class MetadataFileGenerator implements ElementVisitor,
 			Object defVal = field.getDefaultValue();
 			String valueStr = defVal.toString();
 			if (type instanceof PrimitiveFieldType && 
-			   ((PrimitiveFieldType) type).getType() == PrimitiveType.STRING) {
+			   ((PrimitiveFieldType) type).getPrimitiveType() == PrimitiveType.STRING) {
 				valueStr = "\"" + valueStr + "\"";
 				
 			}

--- a/RecordBuffers/src/main/java/datamine/storage/idl/json/JsonSchemaConvertor.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/json/JsonSchemaConvertor.java
@@ -80,7 +80,7 @@ public class JsonSchemaConvertor implements JsonElementVisitor,
 		// Sanity check: 
 		/// 1. an optional primitive field must have a default value
 		if (defaultValue == null && type instanceof PrimitiveFieldType && !field.isRequired()) {
-			if (((PrimitiveFieldType) type).getType() != PrimitiveType.BINARY) {
+			if (((PrimitiveFieldType) type).getPrimitiveType() != PrimitiveType.BINARY) {
 				throw new IllegalArgumentException("Default value " +
 						"is required for the optional primitive column - " + field.getName());				
 			}

--- a/RecordBuffers/src/main/java/datamine/storage/idl/type/CollectionFieldType.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/type/CollectionFieldType.java
@@ -29,7 +29,7 @@ final public class CollectionFieldType implements FieldType {
 		return elementType;
 	}
 
-	public CollectionType getType() {
+	public CollectionType getCollectionType() {
 		return collectionType;
 	}
 

--- a/RecordBuffers/src/main/java/datamine/storage/idl/type/PrimitiveFieldType.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/type/PrimitiveFieldType.java
@@ -30,7 +30,7 @@ final public class PrimitiveFieldType implements FieldType {
 		this.type = gType;
 	}
 
-	public PrimitiveType getType() {
+	public PrimitiveType getPrimitiveType() {
 		return type;
 	}
 

--- a/RecordBuffers/src/main/java/datamine/storage/idl/validate/FieldValidation.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/validate/FieldValidation.java
@@ -86,7 +86,7 @@ class FieldValidation implements ValidateInterface<Field> {
 		Object defaultVal = input.getDefaultValue();
 		
 		if (type instanceof PrimitiveFieldType && 
-			((PrimitiveFieldType) type).getType() != PrimitiveType.BINARY && 
+			((PrimitiveFieldType) type).getPrimitiveType() != PrimitiveType.BINARY && 
 			!input.isRequired()) {
 			
 			if (!FieldValueOperatorFactory.getOperator(type).isValid(defaultVal)) {

--- a/RecordBuffers/src/main/java/datamine/storage/idl/validate/SchemaEvolutionValidation.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/validate/SchemaEvolutionValidation.java
@@ -172,7 +172,7 @@ public class SchemaEvolutionValidation implements ValidateInterface<Schema> {
 
 		// check the default value
 		if (!current.isRequired() && current.getType() instanceof PrimitiveFieldType &&
-			((PrimitiveFieldType) current.getType()).getType() != PrimitiveType.BINARY && 
+			((PrimitiveFieldType) current.getType()).getPrimitiveType() != PrimitiveType.BINARY && 
 			!current.getDefaultValue().equals(next.getDefaultValue())) {
 			throw new FieldDefaultValueModifiedInSchemaEvolutionException(current.getName());
 		}

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/ReadOnlyRecord.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/ReadOnlyRecord.java
@@ -130,7 +130,7 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 		Object result = null;
 		int offset = getOffset(field);
 		if (offset > 0 && type instanceof PrimitiveFieldType) {
-			PrimitiveType priType = ((PrimitiveFieldType) type).getType();
+			PrimitiveType priType = ((PrimitiveFieldType) type).getPrimitiveType();
 			switch (priType) {
 			case STRING:
 				result = valueOpr.getValue(buf, offset + 2, buf.getShort(offset));
@@ -351,7 +351,7 @@ public class ReadOnlyRecord<T extends Enum<T> & RecordMetadataInterface> extends
 				FieldType fieldType = curField.getField().getType();
 				FieldValueOperatorInterface valueOpr = FieldValueOperatorFactory.getOperator(fieldType);
 				if (fieldType instanceof PrimitiveFieldType) {
-					switch (((PrimitiveFieldType) fieldType).getType()) {
+					switch (((PrimitiveFieldType) fieldType).getPrimitiveType()) {
 					case STRING:
 						// string requires a SHORT to store its length (max < 32k)
 						short arrayLength = bytebuffer.getShort(offset);

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
@@ -287,7 +287,7 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 				int id = curField.getField().getId() - 1; // note that the ID starts at 1 instead of 0
 				FieldValueOperatorInterface valueOpr = FieldValueOperatorFactory.getOperator(fieldType);
 				if (fieldType instanceof PrimitiveFieldType) {
-					switch (((PrimitiveFieldType) fieldType).getType()) {
+					switch (((PrimitiveFieldType) fieldType).getPrimitiveType()) {
 					case STRING:
 						// string requires a SHORT to store its length (max < 32k)
 						short arrayLength = bytebuffer.getShort(offset);
@@ -461,7 +461,7 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 								curPosition += byteArray.length;
 							} else {
 								if (curFieldType instanceof PrimitiveFieldType && 
-										((PrimitiveFieldType) curFieldType).getType().equals(PrimitiveType.STRING)) {
+										((PrimitiveFieldType) curFieldType).getPrimitiveType().equals(PrimitiveType.STRING)) {
 									if (byteArray.length > Short.MAX_VALUE) {
 										outStream.write(new byte[]{(byte)0,(byte)0});
 										curPosition += 2;

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/idl/generator/RecordMetaWrapperGenerator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/idl/generator/RecordMetaWrapperGenerator.java
@@ -487,7 +487,7 @@ public class RecordMetaWrapperGenerator implements ElementVisitor,
 			String elementTypeStr = new JavaTypeConvertor().apply(elementType);
 			String typeStr = new JavaTypeConvertor().apply(type);
 			
-			switch (type.getType()) {
+			switch (type.getCollectionType()) {
 			case LIST:
 				
 				if (elementType instanceof PrimitiveFieldType) {
@@ -537,7 +537,7 @@ public class RecordMetaWrapperGenerator implements ElementVisitor,
 				break;
 
 			default:
-				throw new IllegalArgumentException("Not support for the type of " + type.getType());
+				throw new IllegalArgumentException("Not support for the type of " + type.getCollectionType());
 			}
 			
 		}
@@ -608,7 +608,7 @@ public class RecordMetaWrapperGenerator implements ElementVisitor,
 			field = input;
 			FieldType type = input.getType();
 			
-			if (type instanceof PrimitiveFieldType && ((PrimitiveFieldType) type).getType() != PrimitiveType.BINARY) {
+			if (type instanceof PrimitiveFieldType && ((PrimitiveFieldType) type).getPrimitiveType() != PrimitiveType.BINARY) {
 				fieldGetterTemplate = new CodeTemplate(code);
 				
 				String javaTypeStr = new JavaTypeConvertor().apply(type);
@@ -620,7 +620,7 @@ public class RecordMetaWrapperGenerator implements ElementVisitor,
 					Object defVal = field.getDefaultValue();
 					String valueStr = defVal.toString();
 					if (type instanceof PrimitiveFieldType && 
-						((PrimitiveFieldType) type).getType() == PrimitiveType.STRING) {
+						((PrimitiveFieldType) type).getPrimitiveType() == PrimitiveType.STRING) {
 						valueStr = "\"" + valueStr + "\"";
 						
 					}
@@ -667,7 +667,7 @@ public class RecordMetaWrapperGenerator implements ElementVisitor,
 			String enumName = MetadataFileGenerator.getEnumValue(field.getName());
 			String colName = metadataClassName + "." + enumName;
 			StringBuilder sb = new StringBuilder().append("return this.value.get");
-			switch (type.getType()) {
+			switch (type.getPrimitiveType()) {
 			case BOOL:
 				sb.append("Bool");
 				break;
@@ -696,7 +696,7 @@ public class RecordMetaWrapperGenerator implements ElementVisitor,
 				sb.append("Binary");
 				break;
 			default:
-				throw new IllegalArgumentException("Not supported type : " + type.getType());
+				throw new IllegalArgumentException("Not supported type : " + type.getPrimitiveType());
 			}
 			fieldGetterTemplate.fillFields("returnClause", 
 					sb.append("(").append(colName).append(");").toString());
@@ -733,7 +733,7 @@ public class RecordMetaWrapperGenerator implements ElementVisitor,
 			FieldType elementType = type.getElementType();
 			String javaTypeStr = new JavaTypeConvertor(true).apply(elementType); 
 			
-			switch (type.getType()) {
+			switch (type.getCollectionType()) {
 			case LIST:
 
 				fieldGetterTemplate.fillFields("elementType", javaTypeStr);
@@ -775,7 +775,7 @@ public class RecordMetaWrapperGenerator implements ElementVisitor,
 				break;
 
 			default:
-				throw new IllegalArgumentException("Not support for the type of " + type.getType());
+				throw new IllegalArgumentException("Not support for the type of " + type.getCollectionType());
 			}
 			
 		}

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/idl/value/CollectionValueOperator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/idl/value/CollectionValueOperator.java
@@ -49,7 +49,7 @@ class CollectionValueOperator implements FieldValueOperatorInterface {
 
 	public CollectionValueOperator(CollectionFieldType type) {
 		this.elementType = type.getElementType();
-		this.collectionType = type.getType();
+		this.collectionType = type.getCollectionType();
 	}
 
 	public FieldType getElementType() {
@@ -101,7 +101,7 @@ class CollectionValueOperator implements FieldValueOperatorInterface {
 		//2. start reading values
 		FieldValueOperatorInterface valOpr = FieldValueOperatorFactory.getOperator(elementType);
 		if (elementType instanceof PrimitiveFieldType) {
-			PrimitiveType type = ((PrimitiveFieldType) elementType).getType();
+			PrimitiveType type = ((PrimitiveFieldType) elementType).getPrimitiveType();
 			switch (type) {
 			case STRING:
 				for (int i = 0; i < listSize; i++) {
@@ -154,7 +154,7 @@ class CollectionValueOperator implements FieldValueOperatorInterface {
 		FieldValueOperatorInterface valOpr = FieldValueOperatorFactory.getOperator(elementType);
 		outStream.write(ByteBuffer.allocate(4).putInt(valList.size()).array());
 		if (elementType instanceof PrimitiveFieldType) {
-			PrimitiveType type = ((PrimitiveFieldType) elementType).getType();
+			PrimitiveType type = ((PrimitiveFieldType) elementType).getPrimitiveType();
 			switch (type) {
 			case STRING:
 				for (Object cur : valList) {
@@ -207,7 +207,7 @@ class CollectionValueOperator implements FieldValueOperatorInterface {
 		int num = valList.size();
 		FieldValueOperatorInterface valOpr = FieldValueOperatorFactory.getOperator(elementType);
 		if (elementType instanceof PrimitiveFieldType) {
-			PrimitiveType type = ((PrimitiveFieldType) elementType).getType();
+			PrimitiveType type = ((PrimitiveFieldType) elementType).getPrimitiveType();
 			switch (type) {
 			case STRING:
 				for (Object cur : valList) {

--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/idl/value/PrimitiveValueOperator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/idl/value/PrimitiveValueOperator.java
@@ -41,7 +41,7 @@ class PrimitiveValueOperator implements FieldValueOperatorInterface {
 	
 	public PrimitiveValueOperator(PrimitiveFieldType type) {
 		this.primitiveType = type;
-		switch (type.getType()) {
+		switch (type.getPrimitiveType()) {
 		case BYTE:
 			valueOpr = new ByteValueOperator();
 			break;
@@ -72,7 +72,7 @@ class PrimitiveValueOperator implements FieldValueOperatorInterface {
 		case UNKNOWN:
 		default:
 			valueOpr = null;
-			throw new IllegalArgumentException("It is not a valid primitive type - " + type.getType());
+			throw new IllegalArgumentException("It is not a valid primitive type - " + type.getPrimitiveType());
 		}
 		
 	}

--- a/RecordBuffers/src/test/java/datamine/storage/idl/generator/TableTestDataGenerator.java
+++ b/RecordBuffers/src/test/java/datamine/storage/idl/generator/TableTestDataGenerator.java
@@ -238,7 +238,7 @@ public class TableTestDataGenerator implements ElementVisitor,
 
 			FieldType elementType = type.getElementType();
 
-			switch (type.getType()) {
+			switch (type.getCollectionType()) {
 			case LIST:
 
 				if (elementType instanceof PrimitiveFieldType) {
@@ -269,7 +269,7 @@ public class TableTestDataGenerator implements ElementVisitor,
 				break;
 
 			default:
-				throw new IllegalArgumentException("Not support for the type of " + type.getType());
+				throw new IllegalArgumentException("Not support for the type of " + type.getCollectionType());
 			}
 
 		}
@@ -332,7 +332,7 @@ public class TableTestDataGenerator implements ElementVisitor,
 				.append("RandomValueGenerator.getValueOf(((PrimitiveFieldType)")
 				.append(metadataClassName).append(".")
 				.append(MetadataFileGenerator.getEnumValue(field.getName()))
-				.append(".getField().getType()).getType())").toString();
+				.append(".getField().getType()).getPrimitiveType())").toString();
 			fieldSetterTemplate.fillFields("getFieldValue", returnClause);
 			fieldSetterTemplate.fillFields("checkConditions", "val != null");
 		}
@@ -351,7 +351,7 @@ public class TableTestDataGenerator implements ElementVisitor,
 
 			FieldType elementType = type.getElementType();
 
-			switch (type.getType()) {
+			switch (type.getCollectionType()) {
 			case LIST:
 
 				if (elementType instanceof PrimitiveFieldType) {
@@ -360,7 +360,7 @@ public class TableTestDataGenerator implements ElementVisitor,
 					.append("RandomValueGenerator.getValueArrayOf(((PrimitiveFieldType) ((CollectionFieldType)")
 					.append(metadataClassName).append(".")
 					.append(MetadataFileGenerator.getEnumValue(field.getName()))
-					.append(".getField().getType()).getElementType()).getType(), num)").toString();
+					.append(".getField().getType()).getElementType()).getPrimitiveType(), num)").toString();
 					
 					fieldSetterTemplate.fillFields("getFieldValue", returnClause);
 					
@@ -385,7 +385,7 @@ public class TableTestDataGenerator implements ElementVisitor,
 				break;
 
 			default:
-				throw new IllegalArgumentException("Not support for the type of " + type.getType());
+				throw new IllegalArgumentException("Not support for the type of " + type.getCollectionType());
 			}
 
 		}
@@ -487,7 +487,7 @@ public class TableTestDataGenerator implements ElementVisitor,
 			} else if (type instanceof CollectionFieldType) {
 
 				FieldType elementType = ((CollectionFieldType) type).getElementType();
-				switch (((CollectionFieldType) type).getType()) {
+				switch (((CollectionFieldType) type).getCollectionType()) {
 				case LIST:
 					if (elementType instanceof PrimitiveFieldType) {
 
@@ -521,7 +521,7 @@ public class TableTestDataGenerator implements ElementVisitor,
 					break;
 				default:
 					throw new IllegalArgumentException("Not support for the type of " + 
-							((CollectionFieldType) type).getType());
+							((CollectionFieldType) type).getCollectionType());
 				}
 				
 			} else {

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/AnalyticalUserProfileTestData.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/AnalyticalUserProfileTestData.java
@@ -135,28 +135,28 @@ public class AnalyticalUserProfileTestData extends AbstractTestData<AnalyticalUs
 			EnumMap<AnalyticalUserProfileMetadata, Object> dataMap = Maps.newEnumMap(AnalyticalUserProfileMetadata.class);
 			
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.USER_ID.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.USER_ID.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(AnalyticalUserProfileMetadata.USER_ID, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.VERSION.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.VERSION.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(AnalyticalUserProfileMetadata.VERSION, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.RESOLUTION.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.RESOLUTION.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(AnalyticalUserProfileMetadata.RESOLUTION, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.OS_VERSION.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.OS_VERSION.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(AnalyticalUserProfileMetadata.OS_VERSION, val);
 				}
@@ -177,14 +177,14 @@ public class AnalyticalUserProfileTestData extends AbstractTestData<AnalyticalUs
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueArrayOf(((PrimitiveFieldType) ((CollectionFieldType)AnalyticalUserProfileMetadata.TIME_LIST.getField().getType()).getElementType()).getType(), num);
+				Object val = RandomValueGenerator.getValueArrayOf(((PrimitiveFieldType) ((CollectionFieldType)AnalyticalUserProfileMetadata.TIME_LIST.getField().getType()).getElementType()).getPrimitiveType(), num);
 				if (val != null && !((List) val).isEmpty()) {
 					dataMap.put(AnalyticalUserProfileMetadata.TIME_LIST, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.DATA.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AnalyticalUserProfileMetadata.DATA.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(AnalyticalUserProfileMetadata.DATA, val);
 				}

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/AttributionResultRuleTestData.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/AttributionResultRuleTestData.java
@@ -83,14 +83,14 @@ public class AttributionResultRuleTestData extends AbstractTestData<AttributionR
 			EnumMap<AttributionResultRuleMetadata, Object> dataMap = Maps.newEnumMap(AttributionResultRuleMetadata.class);
 			
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AttributionResultRuleMetadata.RUN_NUM.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AttributionResultRuleMetadata.RUN_NUM.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(AttributionResultRuleMetadata.RUN_NUM, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AttributionResultRuleMetadata.VALUE.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AttributionResultRuleMetadata.VALUE.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(AttributionResultRuleMetadata.VALUE, val);
 				}

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/AttributionResultTestData.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/AttributionResultTestData.java
@@ -83,7 +83,7 @@ public class AttributionResultTestData extends AbstractTestData<AttributionResul
 			EnumMap<AttributionResultMetadata, Object> dataMap = Maps.newEnumMap(AttributionResultMetadata.class);
 			
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AttributionResultMetadata.ID.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)AttributionResultMetadata.ID.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(AttributionResultMetadata.ID, val);
 				}

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/ImpressionTestData.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/ImpressionTestData.java
@@ -131,35 +131,35 @@ public class ImpressionTestData extends AbstractTestData<ImpressionInterface, Im
 			EnumMap<ImpressionMetadata, Object> dataMap = Maps.newEnumMap(ImpressionMetadata.class);
 			
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.MEDIA_PROVIDER_ID.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.MEDIA_PROVIDER_ID.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(ImpressionMetadata.MEDIA_PROVIDER_ID, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.MP_TPT_CATEGORY_ID.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.MP_TPT_CATEGORY_ID.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(ImpressionMetadata.MP_TPT_CATEGORY_ID, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.TRUNCATED_URL.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.TRUNCATED_URL.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(ImpressionMetadata.TRUNCATED_URL, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.BID.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.BID.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(ImpressionMetadata.BID, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.BID_TYPE.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.BID_TYPE.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(ImpressionMetadata.BID_TYPE, val);
 				}
@@ -173,14 +173,14 @@ public class ImpressionTestData extends AbstractTestData<ImpressionInterface, Im
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.ALLOWED_AD_FORMATS.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.ALLOWED_AD_FORMATS.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(ImpressionMetadata.ALLOWED_AD_FORMATS, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.COST.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ImpressionMetadata.COST.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(ImpressionMetadata.COST, val);
 				}

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/ProviderUserIdTestData.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/data/ProviderUserIdTestData.java
@@ -83,14 +83,14 @@ public class ProviderUserIdTestData extends AbstractTestData<ProviderUserIdInter
 			EnumMap<ProviderUserIdMetadata, Object> dataMap = Maps.newEnumMap(ProviderUserIdMetadata.class);
 			
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ProviderUserIdMetadata.PROVIDER_TYPE.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ProviderUserIdMetadata.PROVIDER_TYPE.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(ProviderUserIdMetadata.PROVIDER_TYPE, val);
 				}
 			}
 
 			{
-				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ProviderUserIdMetadata.PROVIDER_ID.getField().getType()).getType());
+				Object val = RandomValueGenerator.getValueOf(((PrimitiveFieldType)ProviderUserIdMetadata.PROVIDER_ID.getField().getType()).getPrimitiveType());
 				if (val != null) {
 					dataMap.put(ProviderUserIdMetadata.PROVIDER_ID, val);
 				}

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/builder/RecordBuffersBuilder.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/builder/RecordBuffersBuilder.java
@@ -39,28 +39,28 @@ public class RecordBuffersBuilder implements RecordBuilderInterface {
 
 		try {
 			
-		if (tableClass == AnalyticalUserProfileInterface.class) {
-			return (T) AnalyticalUserProfileRecord.class.newInstance();
-		}
-		else
 		if (tableClass == AttributionResultInterface.class) {
 			return (T) AttributionResultRecord.class.newInstance();
-		}
-		else
-		if (tableClass == ImpressionInterface.class) {
-			return (T) ImpressionRecord.class.newInstance();
-		}
-		else
-		if (tableClass == ProviderUserIdInterface.class) {
-			return (T) ProviderUserIdRecord.class.newInstance();
 		}
 		else
 		if (tableClass == AttributionResultRuleInterface.class) {
 			return (T) AttributionResultRuleRecord.class.newInstance();
 		}
 		else
+		if (tableClass == ImpressionInterface.class) {
+			return (T) ImpressionRecord.class.newInstance();
+		}
+		else
 		if (tableClass == IdMapInterface.class) {
 			return (T) IdMapRecord.class.newInstance();
+		}
+		else
+		if (tableClass == AnalyticalUserProfileInterface.class) {
+			return (T) AnalyticalUserProfileRecord.class.newInstance();
+		}
+		else
+		if (tableClass == ProviderUserIdInterface.class) {
+			return (T) ProviderUserIdRecord.class.newInstance();
 		}
 
 		} catch (InstantiationException e) {


### PR DESCRIPTION
To make it easy to see the purpose of getter function of value type, we
improved the naming conversion by
1. changing PrimitiveFieldType.getType() into
   PrimitiveFieldType.getPrimitiveType(), and
2. changing CollectionFieldType.getType() into
   CollectionFieldType.getCollectionType()
