### PR TITLE
Fix bug with vector length in writable record

### DIFF
--- a/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
+++ b/RecordBuffers/src/main/java/datamine/storage/recordbuffers/WritableRecord.java
@@ -274,7 +274,7 @@ public class WritableRecord<T extends Enum<T> & RecordMetadataInterface> extends
 		short refSectionLength = bytebuffer.getShort(initOffset + 4);
 		int posOfAttrs = refSectionLength + 6 + initOffset;
 	
-		valueArray = new Object[length];
+		valueArray = new Object[Math.max(length, fieldList.size())]; // in case we have to update the existing record
 
 		int offset = posOfAttrs + (length + 7) / 8; // skip # of attrs, flags;
 		for (int i = 0; i < length; i++) {


### PR DESCRIPTION
In WritableRecord, there is an object array that contains the value or
update of each attribute in the record.

The length of the array is defined when the record is stored, which may
not be aligned with the CURRENT metadata. This can cause an exception if
the OLD record is updated.

The fix will make the length of the array based on the CURRENT table
schema.
