### PR TITLE
Added the support for printing out the content of a table record

### DIFF
--- a/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/InterfaceContentPrinterGenerator.java
+++ b/RecordBuffers/src/main/java/datamine/storage/idl/generator/java/InterfaceContentPrinterGenerator.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (C) 2015 Turn Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package datamine.storage.idl.generator.java;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import datamine.operator.UnaryOperatorInterface;
+import datamine.storage.idl.ElementVisitor;
+import datamine.storage.idl.Field;
+import datamine.storage.idl.Schema;
+import datamine.storage.idl.Table;
+import datamine.storage.idl.generator.CodeGenerator;
+import datamine.storage.idl.generator.CodeTemplate;
+import datamine.storage.idl.type.CollectionFieldType;
+import datamine.storage.idl.type.CollectionType;
+import datamine.storage.idl.type.FieldType;
+import datamine.storage.idl.type.GroupFieldType;
+import datamine.storage.idl.type.PrimitiveFieldType;
+
+public class InterfaceContentPrinterGenerator implements ElementVisitor, CodeGenerator {
+	
+	private Map<Table, CodeGenerator> templateMap = null;
+	private CodeTemplate currentTemplate = null;
+	
+	private final String sourceDir;
+	private final String nameSpace;
+	private final String interfaceNameSpace;
+	
+	public InterfaceContentPrinterGenerator(String dir, String nameSpace, String interfacePakcage) {
+		this.sourceDir = dir;
+		this.nameSpace = nameSpace;
+		this.interfaceNameSpace = interfacePakcage;
+	}
+	
+	@Override
+	public void visit(Schema schema) {
+		templateMap = new HashMap<Table, CodeGenerator>();
+	}
+
+	@Override
+	public void visit(Table table) {
+		String[] classCode = {
+				"public class {className} implements UnaryOperatorInterface<{interface}, String> {",
+				"",
+				"	@Override",
+				"	public String apply({interface} input) {",
+				"		StringBuffer out = new StringBuffer();",
+				"		out.append(\"{\\n\");",
+				"{printFields}",
+				"		out.append(\"}\");",
+				"		return out.toString();",
+				"	}",
+				"",
+				"}"
+		};
+		
+		String[] importString = {
+				"import " + this.interfaceNameSpace + ".*;",
+				"import datamine.operator.UnaryOperatorInterface;",
+		};
+		
+		CodeTemplate bodyTemplate = new CodeTemplate(classCode);
+		CodeTemplate importTemplate = new CodeTemplate(importString);
+		String className = InterfaceGenerator.getInterfaceName(table.getName()) + "ContentPrinter";
+		JavaCodeGenerator javaCode = new JavaCodeGenerator(sourceDir,
+				nameSpace, className, importTemplate, bodyTemplate);
+		bodyTemplate.fillFields("interface", InterfaceGenerator.getInterfaceName(table.getName()));
+		bodyTemplate.fillFields("className", className);
+		templateMap.put(table, javaCode);
+		currentTemplate = bodyTemplate;
+	}
+
+	@Override
+	public void visit(Field field) {
+				
+		CodeTemplate fieldCode = new FieldTemplateGenerator().apply(field);				
+		fieldCode.fillFields("getter", InterfaceGenerator.getGetterName(field));
+		
+		//Add field change into body
+		currentTemplate.fillFields("printFields", fieldCode);
+	}
+
+	@Override
+	public void generate() {
+		for (Entry<Table, CodeGenerator> entry : templateMap.entrySet()) {
+			entry.getValue().generate();
+		}
+	}
+	
+	
+	/**
+	 * The class, {@link FieldTemplateGenerator} creates the template for the input
+	 * field type.
+	 * 
+	 * @author yqi
+	 * @date Dec 16, 2014
+	 */
+	static class FieldTemplateGenerator 
+		implements UnaryOperatorInterface<Field, CodeTemplate> {
+		
+		private FieldType type;
+		private String name;
+
+		private CodeTemplate createPrimitiveFieldTypeTemplate(PrimitiveFieldType type) {
+			final String[] primitive = {
+					"\t\tout.append(\""+name+" = \").append(input.{getter}()).append(\"\\n\");",
+				};
+			return new CodeTemplate(primitive);
+		}
+		
+		private CodeTemplate createGroupFieldTypeTemplate(GroupFieldType type) {
+			final String[] struct = {
+					"		{",
+					"			{interface}ContentPrinter printer = new {interface}ContentPrinter();",
+					"			if (input.{getter}() != null) {",
+					"       		out.append(\""+name+" = \").append(printer.apply(input.{getter}())).append(\"\\n\");",
+					"			}",
+					"		}",
+				};
+			
+			CodeTemplate fieldCode = null;
+			fieldCode = new CodeTemplate(struct);
+			fieldCode.fillFields("interface", 
+					InterfaceGenerator.getInterfaceName(type.getGroupName()));	
+			return fieldCode;
+		}
+		
+		private CodeTemplate createCollectionFieldTypeTemplate(CollectionFieldType type) {
+			final String[] StructList = {
+					"		{",
+					"			{interface}ContentPrinter printer = new {interface}ContentPrinter();",
+					"			out.append(\""+name+" = \").append(\"[\").append(\"\\n\");",
+					"			for ({interface} tuple: input.{getter}()) {",
+					"				out.append(printer.apply(tuple)).append(\"\\n\");",
+					"			}",
+					"			out.append(\"]\").append(\"\\n\");",
+					"		}"
+			};
+			
+			CodeTemplate fieldCode = null;
+			if (type.getCollectionType() == CollectionType.LIST) {
+				FieldType elementType = type.getElementType();
+				if (elementType instanceof PrimitiveFieldType) {
+					fieldCode = createPrimitiveFieldTypeTemplate((PrimitiveFieldType) elementType);
+				} else if (elementType instanceof GroupFieldType){
+					fieldCode = new CodeTemplate(StructList);
+					fieldCode.fillFields("interface", 
+							InterfaceGenerator.getInterfaceName(
+									((GroupFieldType) elementType).getGroupName()));	
+				} else {
+					throw new IllegalArgumentException("Not support more than 2 levels of nesting type");
+				}
+				
+			} else {
+				throw new IllegalArgumentException("Not support the type of " +
+						((CollectionFieldType) type).getCollectionType());
+			}
+			return fieldCode;
+		}
+		
+		@Override
+		public CodeTemplate apply(Field input) {
+			type = input.getType();
+			name = input.getName();
+			if (type instanceof PrimitiveFieldType) {
+				return createPrimitiveFieldTypeTemplate((PrimitiveFieldType) type);
+			} else if (type instanceof GroupFieldType) {
+				return createGroupFieldTypeTemplate((GroupFieldType) type);
+			} else if (type instanceof CollectionFieldType) {
+				return createCollectionFieldTypeTemplate((CollectionFieldType) type);
+			} else {
+				throw new IllegalArgumentException("Not support the type of " + type);
+			}
+		}
+	}
+}

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/ReadWriteTest.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/ReadWriteTest.java
@@ -206,7 +206,6 @@ public class ReadWriteTest {
 		aup.setIntSortedColumn(101);
 		aup.setLongRequiredColumn(1000L);
 		String output = new MainTableInterfaceContentPrinter().apply(aup);
-		System.out.println(output);
 		String content = "{\r\n" + 
 				"long_required_column = 1000\r\n" + 
 				"int_sorted_column = 101\r\n" + 

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/ReadWriteTest.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/ReadWriteTest.java
@@ -36,6 +36,7 @@ import datamine.storage.recordbuffers.example.interfaces.MainTableInterface;
 import datamine.storage.recordbuffers.example.interfaces.SecondLevelNestedTableInterface;
 import datamine.storage.recordbuffers.example.interfaces.StructTableInterface;
 import datamine.storage.recordbuffers.example.model.MainTableMetadata;
+import datamine.storage.recordbuffers.example.printers.MainTableInterfaceContentPrinter;
 import datamine.storage.recordbuffers.example.wrapper.FirstLevelNestedTableRecord;
 import datamine.storage.recordbuffers.example.wrapper.MainTableRecord;
 import datamine.storage.recordbuffers.example.wrapper.SecondLevelNestedTableRecord;
@@ -51,11 +52,11 @@ public class ReadWriteTest {
 	@SuppressWarnings("rawtypes")
 	private List<Record> recordList = Lists.newArrayList();
 	private int recordNum = 3;
-	
+
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@BeforeMethod
 	private void prepareRecord() {
-		
+
 		mainTableTestData = new MainTableTestData(MainTableTestData.createInputData(recordNum));
 		mainTableList = mainTableTestData.createObjects(new RecordBuffersBuilder());
 		recordList.clear();
@@ -70,12 +71,12 @@ public class ReadWriteTest {
 	public void getRecordLength() {
 		GroupFieldType gft = new GroupFieldType("main_table", MainTableMetadata.class);
 		int len = FieldValueOperatorFactory.getOperator(gft).getNumOfBytes(mainTableRecord);
-		
+
 		// trigger the creation of the object array
 		mainTableRecord.getValue(MainTableMetadata.NESTED_TABLE_COLUMN);
 		Assert.assertEquals(mainTableRecord.getNumOfBytes(), len);
 	}
-	
+
 	@Test
 	public void getListSize() {
 		Assert.assertEquals(recordNum, mainTableList.size());
@@ -122,12 +123,12 @@ public class ReadWriteTest {
 		for (MainTableInterface cur : mainTableList) {
 			Assert.assertEquals(cur.getStringDerivedColumn(),
 					cur.getStringDerivedColumnDefaultValue());
-			
+
 			MainTableDerivedValueInterface derivedImpl = new MainTableDerived(cur);
 			cur.setDerivedValueImplementation(derivedImpl);
 			Assert.assertEquals("StringDerivedColumn@MainTable", derivedImpl.getStringDerivedColumn());
 			Assert.assertEquals(101, derivedImpl.getIntDerivedColumn());
-			
+
 			for(FirstLevelNestedTableInterface imp : cur.getNestedTableColumn()) {
 				FirstLevelNestedTableDerivedValueInterface impDev = new
 						FirstLevelNestedTableDerived(imp);
@@ -138,8 +139,7 @@ public class ReadWriteTest {
 		}
 	}
 
-	@Test
-	public void recordCreation() {
+	private MainTableInterface createRecord() {
 		// create the record
 		MainTableInterface aup = new MainTableRecord();
 		aup.setStringColumn("1234567890");
@@ -156,7 +156,7 @@ public class ReadWriteTest {
 			ids.add(rand.nextInt());
 		}
 		aup.setIntListColumn(ids);
-		
+
 		FirstLevelNestedTableInterface nestedTable = new FirstLevelNestedTableRecord();
 		nestedTable.setIntRequiredColumn(202);
 		SecondLevelNestedTableInterface snt = new SecondLevelNestedTableRecord();
@@ -169,15 +169,22 @@ public class ReadWriteTest {
 		List<SecondLevelNestedTableInterface> snts = Lists.newArrayList();
 		snts.add(snt);
 		nestedTable.setNestedTableColumn(snts);
-		
+
 		List<FirstLevelNestedTableInterface> nts = Lists.newArrayList();
 		nts.add(nestedTable);
 		aup.setNestedTableColumn(nts);
-		
+
 		StructTableInterface sti = new StructTableRecord();
 		sti.setNestedTableColumn(snts);
 		aup.setStructColumn(sti);
-		
+
+		return aup;
+	}
+
+	@Test
+	public void recordCreation() {
+
+		MainTableInterface aup = createRecord();
 		@SuppressWarnings("unchecked")
 		Record<MainTableMetadata> aupRecord = (Record<MainTableMetadata>) aup.getBaseObject();
 		// start testing
@@ -192,5 +199,30 @@ public class ReadWriteTest {
 		GroupFieldType gft = new GroupFieldType("main_table", MainTableMetadata.class);
 		Assert.assertEquals(len, FieldValueOperatorFactory.getOperator(gft).getNumOfBytes(aupRecord));
 	}
-
+	
+	@Test
+	public void printContent1() {
+		MainTableInterface aup = new MainTableRecord();
+		aup.setIntSortedColumn(101);
+		aup.setLongRequiredColumn(1000L);
+		String output = new MainTableInterfaceContentPrinter().apply(aup);
+		System.out.println(output);
+		String content = "{\r\n" + 
+				"long_required_column = 1000\r\n" + 
+				"int_sorted_column = 101\r\n" + 
+				"byte_column = -1\r\n" + 
+				"boolean_column = false\r\n" + 
+				"short_column = 0\r\n" + 
+				"float_column = 0.0\r\n" + 
+				"double_column = 0.001\r\n" + 
+				"string_column = Unknown\r\n" + 
+				"binary_column = null\r\n" + 
+				"nested_table_column = [\r\n" + 
+				"]\r\n" + 
+				"int_list_column = []\r\n" + 
+				"string_derived_column = Unknown\r\n" + 
+				"int_derived_column = 0\r\n" + 
+				"}";
+		Assert.assertEquals(output.replaceAll("\\s", ""), content.trim().replaceAll("\\s", ""));
+	}
 }

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/GenerateTestData.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/GenerateTestData.java
@@ -28,6 +28,7 @@ import datamine.storage.idl.Schema;
 import datamine.storage.idl.generator.TableTestDataGenerator;
 import datamine.storage.idl.generator.java.InterfaceConvertorGenerator;
 import datamine.storage.idl.generator.java.InterfaceGenerator;
+import datamine.storage.idl.generator.java.InterfaceContentPrinterGenerator;
 import datamine.storage.idl.generator.metadata.MetadataFileGenerator;
 import datamine.storage.idl.json.JsonSchemaConvertor;
 import datamine.storage.idl.validate.SchemaValidation;
@@ -70,6 +71,7 @@ public class GenerateTestData {
 			generateTableMetadataEnums();
 			generateTableAccessImps();
 			generateTableAccessTestData();
+			generateTableContentPrinters();
 			
 		} catch (IOException e) {
 			LOG.error("Cannot generate the code for the schema at " + this.schemaFile, e);
@@ -96,6 +98,17 @@ public class GenerateTestData {
 		// generate the java source codes
 		schema.accept(generator0);
 		generator0.generate();
+	}
+	
+	private void generateTableContentPrinters() {
+		InterfaceContentPrinterGenerator generator = new InterfaceContentPrinterGenerator(
+				genSrcFolder,
+				genClassPackageName + ".printers",
+				genClassPackageName + ".interfaces");
+
+		// generate the java source codes
+		schema.accept(generator);
+		generator.generate();
 	}
 	
 	private void generateTableMetadataEnums() {

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/printers/FirstLevelNestedTableInterfaceContentPrinter.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/printers/FirstLevelNestedTableInterfaceContentPrinter.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 Turn Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package datamine.storage.recordbuffers.example.printers;
+
+import datamine.storage.recordbuffers.example.interfaces.*;
+import datamine.operator.UnaryOperatorInterface;
+
+
+/**
+ * DO NOT CHANGE! Auto-generated code
+ */
+public class FirstLevelNestedTableInterfaceContentPrinter implements UnaryOperatorInterface<FirstLevelNestedTableInterface, String> {
+
+	@Override
+	public String apply(FirstLevelNestedTableInterface input) {
+		StringBuffer out = new StringBuffer();
+		out.append("{\n");
+		out.append("int_required_column = ").append(input.getIntRequiredColumn()).append("\n");
+		{
+			SecondLevelNestedTableInterfaceContentPrinter printer = new SecondLevelNestedTableInterfaceContentPrinter();
+			out.append("nested_table_column = ").append("[").append("\n");
+			for (SecondLevelNestedTableInterface tuple: input.getNestedTableColumn()) {
+				out.append(printer.apply(tuple)).append("\n");
+			}
+			out.append("]").append("\n");
+		}
+		out.append("string_derived_column = ").append(input.getStringDerivedColumn()).append("\n");
+
+		out.append("}");
+		return out.toString();
+	}
+
+}
+

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/printers/MainTableInterfaceContentPrinter.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/printers/MainTableInterfaceContentPrinter.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2015 Turn Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package datamine.storage.recordbuffers.example.printers;
+
+import datamine.storage.recordbuffers.example.interfaces.*;
+import datamine.operator.UnaryOperatorInterface;
+
+
+/**
+ * DO NOT CHANGE! Auto-generated code
+ */
+public class MainTableInterfaceContentPrinter implements UnaryOperatorInterface<MainTableInterface, String> {
+
+	@Override
+	public String apply(MainTableInterface input) {
+		StringBuffer out = new StringBuffer();
+		out.append("{\n");
+		out.append("long_required_column = ").append(input.getLongRequiredColumn()).append("\n");
+		out.append("int_sorted_column = ").append(input.getIntSortedColumn()).append("\n");
+		out.append("byte_column = ").append(input.getByteColumn()).append("\n");
+		out.append("boolean_column = ").append(input.isBooleanColumn()).append("\n");
+		out.append("short_column = ").append(input.getShortColumn()).append("\n");
+		out.append("float_column = ").append(input.getFloatColumn()).append("\n");
+		out.append("double_column = ").append(input.getDoubleColumn()).append("\n");
+		out.append("string_column = ").append(input.getStringColumn()).append("\n");
+		out.append("binary_column = ").append(input.getBinaryColumn()).append("\n");
+		{
+			FirstLevelNestedTableInterfaceContentPrinter printer = new FirstLevelNestedTableInterfaceContentPrinter();
+			out.append("nested_table_column = ").append("[").append("\n");
+			for (FirstLevelNestedTableInterface tuple: input.getNestedTableColumn()) {
+				out.append(printer.apply(tuple)).append("\n");
+			}
+			out.append("]").append("\n");
+		}
+		{
+			StructTableInterfaceContentPrinter printer = new StructTableInterfaceContentPrinter();
+			if (input.getStructColumn() != null) {
+       		out.append("struct_column = ").append(printer.apply(input.getStructColumn())).append("\n");
+			}
+		}
+		out.append("int_list_column = ").append(input.getIntListColumn()).append("\n");
+		out.append("string_derived_column = ").append(input.getStringDerivedColumn()).append("\n");
+		out.append("int_derived_column = ").append(input.getIntDerivedColumn()).append("\n");
+
+		out.append("}");
+		return out.toString();
+	}
+
+}
+

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/printers/SecondLevelNestedTableInterfaceContentPrinter.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/printers/SecondLevelNestedTableInterfaceContentPrinter.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Turn Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package datamine.storage.recordbuffers.example.printers;
+
+import datamine.storage.recordbuffers.example.interfaces.*;
+import datamine.operator.UnaryOperatorInterface;
+
+
+/**
+ * DO NOT CHANGE! Auto-generated code
+ */
+public class SecondLevelNestedTableInterfaceContentPrinter implements UnaryOperatorInterface<SecondLevelNestedTableInterface, String> {
+
+	@Override
+	public String apply(SecondLevelNestedTableInterface input) {
+		StringBuffer out = new StringBuffer();
+		out.append("{\n");
+		out.append("byte_required_column = ").append(input.getByteRequiredColumn()).append("\n");
+		out.append("boolean_list_column = ").append(input.getBooleanListColumn()).append("\n");
+
+		out.append("}");
+		return out.toString();
+	}
+
+}
+

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/printers/StructTableInterfaceContentPrinter.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/printers/StructTableInterfaceContentPrinter.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 Turn Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package datamine.storage.recordbuffers.example.printers;
+
+import datamine.storage.recordbuffers.example.interfaces.*;
+import datamine.operator.UnaryOperatorInterface;
+
+
+/**
+ * DO NOT CHANGE! Auto-generated code
+ */
+public class StructTableInterfaceContentPrinter implements UnaryOperatorInterface<StructTableInterface, String> {
+
+	@Override
+	public String apply(StructTableInterface input) {
+		StringBuffer out = new StringBuffer();
+		out.append("{\n");
+		{
+			SecondLevelNestedTableInterfaceContentPrinter printer = new SecondLevelNestedTableInterfaceContentPrinter();
+			out.append("nested_table_column = ").append("[").append("\n");
+			for (SecondLevelNestedTableInterface tuple: input.getNestedTableColumn()) {
+				out.append(printer.apply(tuple)).append("\n");
+			}
+			out.append("]").append("\n");
+		}
+
+		out.append("}");
+		return out.toString();
+	}
+
+}
+

--- a/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/builder/RecordBuffersBuilder.java
+++ b/RecordBuffers/src/test/java/datamine/storage/recordbuffers/example/wrapper/builder/RecordBuffersBuilder.java
@@ -39,20 +39,20 @@ public class RecordBuffersBuilder implements RecordBuilderInterface {
 
 		try {
 			
-		if (tableClass == SecondLevelNestedTableInterface.class) {
-			return (T) SecondLevelNestedTableRecord.class.newInstance();
-		}
-		else
 		if (tableClass == MainTableInterface.class) {
 			return (T) MainTableRecord.class.newInstance();
 		}
 		else
-		if (tableClass == StructTableInterface.class) {
-			return (T) StructTableRecord.class.newInstance();
+		if (tableClass == SecondLevelNestedTableInterface.class) {
+			return (T) SecondLevelNestedTableRecord.class.newInstance();
 		}
 		else
 		if (tableClass == FirstLevelNestedTableInterface.class) {
 			return (T) FirstLevelNestedTableRecord.class.newInstance();
+		}
+		else
+		if (tableClass == StructTableInterface.class) {
+			return (T) StructTableRecord.class.newInstance();
 		}
 
 		} catch (InstantiationException e) {

--- a/recordbuffers-maven-plugin/src/main/java/datamine/mojo/storage/TableInterfaceConvertorGenerationMojo.java
+++ b/recordbuffers-maven-plugin/src/main/java/datamine/mojo/storage/TableInterfaceConvertorGenerationMojo.java
@@ -28,8 +28,8 @@ import datamine.storage.idl.generator.java.InterfaceConvertorGenerator;
 import datamine.storage.idl.json.JsonSchemaConvertor;
 
 /**
- * Goal which creates a set of Java interfaces for table access based on 
- * the input schema (e.g., a JSON file).
+ * Goal which creates a set of Java classes to copy a table record as an interface
+ * into another table record as the same interface. 
  *
  * @goal table_interface_convertors
  * 

--- a/recordbuffers-maven-plugin/src/main/java/datamine/mojo/storage/recordbuffers/RecordBuffersTableGenerationMojo.java
+++ b/recordbuffers-maven-plugin/src/main/java/datamine/mojo/storage/recordbuffers/RecordBuffersTableGenerationMojo.java
@@ -29,8 +29,8 @@ import datamine.storage.idl.json.JsonSchemaConvertor;
 import datamine.storage.recordbuffers.idl.generator.RecordMetaWrapperGenerator;
 
 /**
- * Goal which creates a set of Java interfaces for table access based on 
- * the input schema (e.g., a JSON file).
+ * Goal which creates a set of Java classes as the implementation of 
+ * the table access interfaces. 
  *
  * @goal record_buffer_tables
  * 


### PR DESCRIPTION
A code generation is defined to create a Java class to read a table
record as an interface and write its content as a string.

Example is changed to test the feature.

Unit test is also added.
